### PR TITLE
Force phiX splitting and for reads >= 100bp use bwa mem

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - get informatrion about a spike directly from lims
  - use old bam_alignment.pl, not P4, if omission of alignments requested
  - option (default on) to force analyses to assume phix spike
  - force P4 and so bwa mem for runs with reads > 100bp

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - force P4 and so bwa mem for runs with reads > 100bp
  - enable human split for P4 in seq_alignment
  - gclp-specific function list for archival
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - enable human split for P4 in seq_alignment
  - gclp-specific function list for archival
 
 release 48.2

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - option (default on) to force analyses to assume phix spike
  - force P4 and so bwa mem for runs with reads > 100bp
  - enable human split for P4 in seq_alignment
  - gclp-specific function list for archival

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - use old bam_alignment.pl, not P4, if omission of alignments requested
  - option (default on) to force analyses to assume phix spike
  - force P4 and so bwa mem for runs with reads > 100bp
  - enable human split for P4 in seq_alignment

--- a/Changes
+++ b/Changes
@@ -5,7 +5,7 @@ LIST OF CHANGES
  - use old bam_alignment.pl, not P4, if omission of alignments requested
  - option (default on) to force analyses to assume phix spike
  - force P4 and so bwa mem for runs with reads > 100bp
- - enable human split for P4 in seq_alignment
+ - enable human split for P4 in seq_alignment (using bwa aln, adapter trimming)
  - gclp-specific function list for archival
 
 release 48.2

--- a/lib/npg_pipeline/analysis/harold_calibration_bam.pm
+++ b/lib/npg_pipeline/analysis/harold_calibration_bam.pm
@@ -297,7 +297,7 @@ sub _lane_has_spiked_phix {
     return;
   }
 
-  if ( $run_lane->is_spiked_phix() ) {
+  if ( $run_lane->is_spiked_phix() or $self->force_phix_split) {
     return 1;
   }
 

--- a/lib/npg_pipeline/analysis/harold_calibration_bam.pm
+++ b/lib/npg_pipeline/analysis/harold_calibration_bam.pm
@@ -342,10 +342,6 @@ sub _generate_calibration_table_per_lane {
 
   my $run_lane = $arg_refs->{run_lane};
 
-  if (! $run_lane->is_spiked_phix() ){
-     return;
-  }
-
   my $position = $run_lane->position();
   my $job_ids  = $arg_refs->{job_ids};
 
@@ -372,9 +368,6 @@ sub _generate_alignment_file_per_lane {
   my ( $self, $arg_refs ) = @_;
 
   my $run_lane = $arg_refs->{run_lane};
-  if (! $run_lane->is_spiked_phix() ) {
-     return;
-  }
 
   my $bsub_command = $self->_alignment_file_bsub_command( {
     position => $run_lane->position(),
@@ -614,7 +607,7 @@ sub _calibration_table_bsub_command {
 
   if ( $arg_refs->{is_spiked_phix} ) {
     if (!$arg_refs->{snp_file}) {
-      croak 'Snip file not available';
+      croak 'SNP file not available';
     }
     push @command, q{--snp } . $arg_refs->{snp_file};
   }

--- a/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
+++ b/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
@@ -172,6 +172,7 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
       $self->_ref($l,q(fasta)) and
       not $spike_tag
     )){
+    #TODO: allow for an analysis genuinely with out phix and where no phiX split work is wanted - especially the phix plex....
     #TODO: support these various options in P4 analyses
     croak qq{only paired reads supported ($name_root)} if not $self->is_paired_read;
     croak qq{No alignments in bam not yet supported ($name_root)} if not $l->alignments_in_bam;
@@ -263,6 +264,7 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
                          q(');
   }else{
     return join q( ),    $DNA_ALIGNMENT_SCRIPT,
+                         ( ($self->force_phix_split and not $spike_tag) ? ( q(--spiked_phix_split) ) : () ), #might be better to turn off split if ref is phix
                          q(--id_run),        $self->id_run,
                          q(--position),      $position,
                          ($is_plex ? ( q(--tag_index),     $tag_index ) : ()),

--- a/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
+++ b/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
@@ -167,13 +167,16 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
   if( $self->force_p4 or (
       ($do_rna or $self->is_hiseqx_run or $self->_is_v4_run or
        any {$_ >= $FORCE_BWAMEM_MIN_READ_CYCLES } $self->read_cycle_counts
+      ) and (
+      #allow old school if no reference or no alignments in bam
+        ($self->_ref($l,q(fasta)) and $l->alignments_in_bam) or
+        $l->contains_nonconsented_human # but not if contains_nonconsented_human
       ) and
-      #allow old school if no reference or if this is the phix spike
-      $self->_ref($l,q(fasta)) and
-      not $spike_tag
+      not $spike_tag #or allow old school if this is the phix spike
     )){
-    #TODO: allow for an analysis genuinely with out phix and where no phiX split work is wanted - especially the phix plex....
-    #TODO: support these various options in P4 analyses
+    #TODO: no alignments or no ref but contains_nonconsented_human and read length >100 
+    #TODO: allow for an analysis genuinely without phix and where no phiX split work is wanted - especially the phix spike plex....
+    #TODO: support this, and above "old school", various options in P4 analyses
     croak qq{only paired reads supported ($name_root)} if not $self->is_paired_read;
     croak qq{No alignments in bam not yet supported ($name_root)} if not $l->alignments_in_bam;
     my $human_split = $l->contains_nonconsented_xahuman ? q(xahuman) :

--- a/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
+++ b/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
@@ -217,7 +217,7 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
                                   ($nchs? (q(-keys hs_alignment_reference_genome -vals), _default_human_split_ref(q{bwa0_6})): ()),   # always human default
                                   q(-keys bwa_executable -vals bwa0_6),
                                   q(-keys alignment_method -vals bwa_mem),
-                                  ($nchs ? q(-keys alignment_hs_method -vals bwa_mem) : ()),
+                                  ($nchs ? q(-keys alignment_hs_method -vals bwa_aln) : ()),
                              ) ),
                              $human_split ? qq(-keys final_output_prep_target_name -vals split_by_chromosome -keys split_indicator -vals _$human_split) : (),
                              $l->separate_y_chromosome_data ? q(-keys split_bam_by_chromosome_flags -vals S=Y -keys split_bam_by_chromosome_flags -vals V=true) : (),

--- a/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
+++ b/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
@@ -25,7 +25,7 @@ Readonly::Scalar our $MEMORY       => q{32000}; # memory in megabytes
 
 =head2 phix_reference
 
-A path to human reference for bwa alignment to split non-consented reads
+A path to phix reference for bwa alignment to split phiX spike-in reads
 
 =cut
 has 'phix_reference' => (isa => 'Str',
@@ -170,7 +170,6 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
     )){
     #TODO: support these various options in P4 analyses
     croak qq{only paired reads supported ($name_root)} if not $self->is_paired_read;
-#    croak qq{nonconsented human split not yet supported ($name_root)} if $l->contains_nonconsented_human;
     croak qq{No alignments in bam not yet supported ($name_root)} if not $l->alignments_in_bam;
     my $human_split = $l->contains_nonconsented_xahuman ? q(xahuman) :
                       $l->separate_y_chromosome_data    ? q(yhuman) :
@@ -193,21 +192,21 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
                              q(-keys af_metrics -vals), $name_root.q{.bam_alignment_filter_metrics.json},
                              q(-keys rpt -vals), $name_root,
                              q(-keys reference_dict -vals), $self->_ref($l,q(picard)).q(.dict),
-                             ($nchs? (q(-keys reference_dict_hs -vals), _default_human_ref(q{picard}),): ()),   # always human default
+                             ($nchs? (q(-keys reference_dict_hs -vals), _default_human_split_ref(q{picard}),): ()),   # always human default
                              q(-keys reference_genome_fasta -vals), $self->_ref($l,q(fasta)),
-                             ($nchs? (q(-keys hs_reference_genome_fasta -vals), _default_human_ref(q{fasta})): ()),   # always human default
+                             ($nchs? (q(-keys hs_reference_genome_fasta -vals), _default_human_split_ref(q{fasta})): ()),   # always human default
                              q(-keys phix_reference_genome_fasta -vals), $self->phix_reference,
                              q(-keys alignment_filter_jar -vals), $self->_AlignmentFilter_jar,
                              ( $do_rna ? (
                                   q(-keys alignment_reference_genome -vals), $self->_ref($l,q(bowtie2)),
-                                  ($nchs? (q(-keys hs_alignment_reference_genome -vals), _default_human_ref(q{bowtie2})): ()),   # always human default
+                                  ($nchs? (q(-keys hs_alignment_reference_genome -vals), _default_human_split_ref(q{bowtie2})): ()),   # always human default
                                   q(-keys library_type -vals), ( $l->library_type =~ /dUTP/smx ? q(fr-firststrand) : q(fr-unstranded) ),
                                   q(-keys transcriptome_val -vals), $self->_transcriptome($l)->transcriptome_index_name(),
                                   q(-keys alignment_method -vals tophat2),
                                   ($nchs ? q(-keys alignment_hs_method -vals tophat2) : ()),
                                ) : (
                                   q(-keys alignment_reference_genome -vals), $self->_ref($l,q(bwa0_6)),
-                                  ($nchs? (q(-keys hs_alignment_reference_genome -vals), _default_human_ref(q{bwa0_6})): ()),   # always human default
+                                  ($nchs? (q(-keys hs_alignment_reference_genome -vals), _default_human_split_ref(q{bwa0_6})): ()),   # always human default
                                   q(-keys bwa_executable -vals bwa0_6),
                                   q(-keys alignment_method -vals bwa_mem),
                                   ($nchs ? q(-keys alignment_hs_method -vals bwa_mem) : ()),
@@ -246,7 +245,6 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
                              $qcpath,
                            q{&&})
                               :(),
-#################
                            $nchs ? (
                            q{perl -e '"'"'use strict; use autodie; use npg_qc::autoqc::results::bam_flagstats; my$}.q{o=npg_qc::autoqc::results::bam_flagstats->new(human_split=>q(}.$nchs_outfile_label.q{), id_run=>$}.q{ARGV[2], position=>$}.q{ARGV[3]}.($is_plex?q{, tag_index=>$}.q{ARGV[4]}:q()).q{); $}.q{o->parsing_metrics_file($}.q{ARGV[0]); open my$}.q{fh,q(<),$}.q{ARGV[1]; $}.q{o->parsing_flagstats($}.q{fh); close$}.q{fh; $}.q{o->store($}.q{ARGV[-1]) '"'"'},
                              (join q{/}, $archive_path, $name_root.q(_).$nchs_outfile_label.q(.markdups_metrics.txt)),
@@ -257,7 +255,6 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
                              $qcpath,
                            q{&&})
                               :(),
-#################
                            q{qc --check alignment_filter_metrics --qc_in $}.q{PWD --id_run}, $self->id_run, qq{--position $position --qc_out $qcpath}, ($is_plex ? (qq{--tag_index $tag_index}) : ()),
                          q(');
   }else{
@@ -419,7 +416,7 @@ sub _default_resources {
   return (join q[ ], npg_pipeline::lsf_job->new(memory => $MEMORY)->memory_spec(), "-R 'span[hosts=$hosts]'", "-n$NUM_THREADS");
 }
 
-sub _default_human_ref {
+sub _default_human_split_ref {
    (my $aligner) = @_;
 
    my $ruser = Moose::Meta::Class->create_anon_class(

--- a/lib/npg_pipeline/base.pm
+++ b/lib/npg_pipeline/base.pm
@@ -200,6 +200,19 @@ sub _build_small_lsf_queue {
   return $self->general_values_conf()->{small_lsf_queue};
 }
 
+=head2 force_phix_split
+
+Boolean decision to force on phix split
+
+=cut
+
+has q{force_phix_split}  => (
+  isa           => q{Bool},
+  is            => q{ro},
+  documentation => q{Boolean decision to force on phiX split},
+  default       => 1,
+);
+
 =head2 force_p4
 
 Boolean decision to force on P4 pipeline usage

--- a/lib/npg_pipeline/roles/business/base.pm
+++ b/lib/npg_pipeline/roles/business/base.pm
@@ -135,6 +135,34 @@ sub is_multiplexed_lane {
   return any {$_ == $position} @{$self->multiplexed_lanes};
 }
 
+sub _lims4lane {
+  my ($self, $position) = @_;
+  if (!$position) {
+    croak 'Position not given';
+  }
+  my $lane = $self->lims->children_ia->{$position};
+  if (!$lane) {
+    croak "Failed to get lims data for lane $position";
+  }
+  return $lane;
+}
+
+=head2 is_spiked_lane
+
+Returns true if the lane is spiked or if the force_phix_split
+flag is set ti true.
+
+=cut
+
+sub is_spiked_lane {
+  my ($self, $position) = @_;
+  if ($self->force_phix_split) {
+    return 1;
+  }
+  my $spike_tag_index = $self->_lims4lane($position)->spiked_phix_tag_index;
+  return (defined $spike_tag_index && $spike_tag_index);
+}
+
 =head2 get_tag_index_list
 
 Returns an array of sorted tag indices for a lane, including tag zero.
@@ -146,11 +174,7 @@ sub get_tag_index_list {
   if (!$self->is_multiplexed_lane($position)) {
     return [];
   }
-  my $lane = $self->lims->children_ia->{$position};
-  if (!$lane) {
-    croak "Failed to get lims data for lane $position";
-  }
-  my @tags = sort keys $lane->tags();
+  my @tags = sort keys $self->_lims4lane($position)->tags();
   unshift @tags, 0;
   return \@tags;
 }

--- a/t/20-archive_file_generation-seq_alignment.t
+++ b/t/20-archive_file_generation-seq_alignment.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 20;
+use Test::More tests => 21;
 use Test::Exception;
 use Test::Deep;
 use File::Temp qw/tempdir/;
@@ -64,6 +64,7 @@ my $rna_gen;
       verbose           => 1,
       repository        => $dir,
       no_bsub           => 1,
+      force_phix_split  => 0,
       ###uncomment to check V4 failure, flowcell_id=>'C333TANXX',
     )
   } 'no error creating an object';
@@ -120,9 +121,24 @@ my $json = qq({"4003":"bash -c ' mkdir -p $dir/140409_HS34_12597_A_C333TACXX/Dat
 
 cmp_deeply(\@lines, [$json ], 'correct json file content (for dUTP library)');
 
+#### force on phix_split
+  lives_ok {
+    $rna_gen = npg_pipeline::archive::file::generation::seq_alignment->new(
+      run_folder        => $runfolder,
+      runfolder_path    => $runfolder_path,
+      recalibrated_path => $bc_path,
+      timestamp         => q{2014},
+      verbose           => 1,
+      repository        => $dir,
+      no_bsub           => 1,
+      force_phix_split  => 1,
+      ###uncomment to check V4 failure, flowcell_id=>'C333TANXX',
+    )
+  } 'no error creating an object (forcing on phix split)';
+
 #####  non-RNASeq libraries (i.e. not Illumina cDNA protocol (unstranded) and RNA-seq dUTP (stranded))  pattern match looks for /(?:cD|R)NA/sxm
 
-  $args->{'5040'} = qq{bam_alignment.pl --id_run 12597 --position 5 --tag_index 40 --input $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/lane5/12597_5#40.bam --output_prefix $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/lane5/12597_5#40 --do_markduplicates  --is_paired_read};
+  $args->{'5040'} = qq{bam_alignment.pl --spiked_phix_split --id_run 12597 --position 5 --tag_index 40 --input $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/lane5/12597_5#40.bam --output_prefix $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/lane5/12597_5#40 --do_markduplicates  --is_paired_read};
  
  lives_ok {$rna_gen->_generate_command_arguments([5])}
      'no error generating command arguments for non-RNASeq lane';
@@ -134,7 +150,7 @@ cmp_deeply(\@lines, [$json ], 'correct json file content (for dUTP library)');
 lives_ok {$rna_gen->_generate_command_arguments([1])}
      'no error generating command arguments for non-multiplex lane';
 
- $args->{'1'} = qq{bam_alignment.pl --id_run 12597 --position 1 --input $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/12597_1.bam --output_prefix $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/12597_1 --do_markduplicates  --is_paired_read};
+ $args->{'1'} = qq{bam_alignment.pl --spiked_phix_split --id_run 12597 --position 1 --input $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/12597_1.bam --output_prefix $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/12597_1 --do_markduplicates  --is_paired_read};
 
  is ($rna_gen->_job_args->{'1'},$args->{'1'},'correct non-multiplex lane args generated');
 

--- a/t/25-harold_calibration_bam.t
+++ b/t/25-harold_calibration_bam.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 34;
+use Test::More tests => 39;
 use Test::Exception::LessClever;
 use t::util;
 use Cwd;
@@ -82,6 +82,7 @@ sub set_staging_analysis_area {
       spatial_filter => 1,
       no_bsub => 1,
       recalibration => 1,
+      force_phix_split => 0,
     });
   } q{create $harold object ok};
 
@@ -199,6 +200,7 @@ sub set_staging_analysis_area {
       bam_basecall_path => $runfolder_path . q{/Data/Intensities/BaseCalls},
       no_bsub => 1,
       recalibration => 1,
+      force_phix_split => 0,
     });
   } q{create $harold object ok};
 
@@ -212,6 +214,37 @@ sub set_staging_analysis_area {
 
   @job_ids = $harold->generate_recalibrated_bam({});
   is( scalar @job_ids, 8, q{8 job ids for recalibration even if no spiked phix lane} );
+}
+
+{
+  set_staging_analysis_area();
+  my $harold;
+  $id_run = 4846;
+  lives_ok {
+    $harold = npg_pipeline::analysis::harold_calibration_bam->new({
+      id_run => $id_run,
+      run_folder => q{123456_IL2_1234},
+      runfolder_path => $runfolder_path,
+      timestamp => q{20091028-101635},
+      verbose => 0,
+      repository => $repos,
+      bam_basecall_path => $runfolder_path . q{/Data/Intensities/BaseCalls},
+      no_bsub => 1,
+      recalibration => 1,
+      force_phix_split => 1,
+    });
+  } q{create $harold object ok};
+
+  isa_ok($harold, q{npg_pipeline::analysis::harold_calibration_bam}, q{$harold});
+
+  my @job_ids = $harold->generate_alignment_files({});
+  is( scalar @job_ids, 8, q{8 job ids for alignment as no spiked phix lane but force phix split} );
+
+  @job_ids = $harold->generate_calibration_table({});
+  is( scalar @job_ids, 8, q{8 job ids for calibration table as no spiked phix lane but force phix split} );
+
+  @job_ids = $harold->generate_recalibrated_bam({});
+  is( scalar @job_ids, 8, q{8 job ids for recalibration even if no spiked phix lane but force phix split} );
 }
 
 {
@@ -231,6 +264,7 @@ sub set_staging_analysis_area {
       no_bsub => 1,
       spatial_filter => 1,
       recalibration => 1,
+      force_phix_split => 0,
     });
   } q{create $harold object ok};
 


### PR DESCRIPTION
Use the P4 bwa mem pipeline by default for runs with reads > 100 bp, and always try to split out phix even if LIMS does not claim run has been spiked with phiX

Also fall back to bam_alignment.pl if no reference or omission of alignments requested (unless human split also requested).