### PR TITLE
Study specific env prework

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,6 +20,7 @@ my $builder = $class->new(
          'dist'                => { COMPRESS => 'gzip', SUFFIX => 'gz', },
 
          'requires'            => {
+          'perl'                         => 5.010,
           'autodie'                      => 0,
           'Carp'                         => 1.04,
           'Cwd'                          => 0,
@@ -41,6 +42,7 @@ my $builder = $class->new(
           'lib'                          => 0,
           'List::MoreUtils'              => 0,
           'List::Util'                   => 0,
+          'Log::Log4perl'                => 0,
           'Moose'                        => 0.93,
           'Moose::Meta::Class'           => 0,
           'Moose::Role'                  => 0,

--- a/Changes
+++ b/Changes
@@ -1,7 +1,14 @@
 LIST OF CHANGES
 ---------------
 
+ - require minimum version 5.10 for perl
  - add study analysis configuration accessor
+ - simpler name for the archival daemon module
+ - parent class for pipeline daemons
+ - consistent behaviour of the archival and analysis daemons
+   when LIMs data are not available in the ml warehouse -
+   the run is skipped
+ - Log::Log4perl logger is used in pipeline daemons
  - pass RG paramater to illumina2bam
  - add archive::file::logs
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - add study analysis configuration accessor
  - pass RG paramater to illumina2bam
  - add archive::file::logs
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -39,7 +39,8 @@ lib/npg_pipeline/archive/qc/illumina_analysis.pm
 lib/npg_pipeline/base.pm
 lib/npg_pipeline/cache.pm
 lib/npg_pipeline/daemons/archival_runner.pm
-lib/npg_pipeline/daemons/harold_analysis_runner.pm
+lib/npg_pipeline/daemons/analysis.pm
+lib/npg_pipeline/daemons/base.pm
 lib/npg_pipeline/dispatch_tree.pm
 lib/npg_pipeline/launcher/status.pm
 lib/npg_pipeline/lsf_job.pm
@@ -88,8 +89,8 @@ t/30-run_folder-link.t
 t/35-archive_file_generation-BamClusterCounts.t
 t/35-archive-file-generation-seqchksum_comparator.t
 t/40-dispatch_tree.t
-t/50-archival_runner.t
-t/50-harold_analysis_runner.t
+t/50-npg_pipeline-daemon-archival.t
+t/50-npg_pipeline-daemon-analysis.t
 t/60-npg_tracking-daemon-analysis.t
 t/60-npg_tracking-daemon-archival.t
 t/bin/bkill

--- a/MANIFEST
+++ b/MANIFEST
@@ -563,6 +563,7 @@ t/data/st/studies/299.xml
 t/data/st/studies/404.xml
 t/data/st/studies/411.xml
 t/data/st/studies/82.xml
+t/data/study_analysis_conf/study_analysis.yml
 t/data/summary_files/after_v7_mp_hack_Summary.htm
 t/data/summary_files/after_v7_mp_hack_Summary.xml
 t/data/summary_files/BustardSummary_mp.xml

--- a/bin/npg_pipeline_archival_runner
+++ b/bin/npg_pipeline_archival_runner
@@ -4,23 +4,30 @@ use strict;
 use warnings;
 use FindBin qw($Bin);
 use lib ( -d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib" );
-use English qw{-no_match_vars};
+use Try::Tiny;
 use Readonly;
+use Log::Log4perl qw(:easy);
+
 use npg_pipeline::daemons::archival_runner;
 
 our $VERSION = '0';
 
-Readonly::Scalar our $SLEEPY_TIME => 900;
+Readonly::Scalar my $SLEEPY_TIME => 900;
+
+Log::Log4perl->easy_init($INFO);
 
 my $runner = npg_pipeline::daemons::archival_runner->new();
 while (1) {
-  eval {
+  try {
+    $runner->logger->info(q{Archival daemon running...});
     $runner->run();
-  } or do {
-    $runner->log( q{Error running archival runner: } . $EVAL_ERROR . q{ - Going to sleep} );
+  } catch {
+    $runner->logger->warn(
+      qq{Error in pipeline archival daemon: $_ - Going to sleep} );
   };
   sleep $SLEEPY_TIME;
 }
+
 0;
 
 __END__
@@ -33,8 +40,8 @@ npg_pipeline_archival_runnner
 
 =head1 DESCRIPTION
 
-Script to run as a daemon which will interrogate npg for runs which have a status of archival_pending, and then
-fire off archival pipeline for each
+Daemon for invoking archival pipeline for runs which have a status of
+'archival pending'.
 
 =head1 USAGE
 
@@ -58,13 +65,15 @@ fire off archival pipeline for each
 
 =item warnings
 
-=item English -no_match_vars
+=item Try::Tiny
 
 =item FindBin
 
 =item Readonly
 
 =item lib
+
+=item Log::Log4perl
 
 =item npg_pipeline::daemons::archival_runner
 
@@ -77,10 +86,11 @@ fire off archival pipeline for each
 =head1 AUTHOR
 
 Andy Brown
+Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2015 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/npg_pipeline_harold_analysis_runner
+++ b/bin/npg_pipeline_harold_analysis_runner
@@ -4,37 +4,45 @@ use strict;
 use warnings;
 use FindBin qw($Bin);
 use lib ( -d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib" );
-use English qw{-no_match_vars};
+use Try::Tiny;
 use Readonly;
-use npg_pipeline::daemons::harold_analysis_runner;
+use Log::Log4perl qw(:easy);
+
+use npg_pipeline::daemons::analysis;
 
 our $VERSION = '0';
 
 Readonly::Scalar our $SLEEPY_TIME => 900;
 
-my $runner = npg_pipeline::daemons::harold_analysis_runner->new();
+Log::Log4perl->easy_init($INFO);
+
+my $runner =  npg_pipeline::daemons::analysis->new();
+
 while (1) {
-  eval {
+  try {
+    $runner->logger->info(q{Analysis daemon running...});
     $runner->run();
-  } or do {
-    $runner->log( q{Error running harold_analysis_runner: } . $EVAL_ERROR . q{ - Going to sleep} );
+  } catch {
+    $runner->logger->warn(
+      qq{Error running pipeline analysis daemon: $_ - Going to sleep});
   };
   sleep $SLEEPY_TIME;
 }
+
 0;
 
 __END__
 
 =head1 NAME
 
-npg_pipeline_archival_runnner
+npg_pipeline_harold_analysis_runnner
 
 =head1 SYNOPSIS
 
 =head1 DESCRIPTION
 
-Script to run as a Daemon which will interrogate npg for runs which have a status of analysis_pending, and then
-fire off analysis pipeline for each
+Starts analysis pipeline for runs that have 'analysis pending' status.
+Captures errors and starts again after a short interval.
 
 =head1 USAGE
 
@@ -58,7 +66,7 @@ fire off analysis pipeline for each
 
 =item warnings
 
-=item English -no_match_vars
+=item Try::Tiny
 
 =item FindBin
 
@@ -66,7 +74,9 @@ fire off analysis pipeline for each
 
 =item lib
 
-=item npg_pipeline::daemons::harold_analysis_runner
+=item Log::Log4perl
+
+=item npg_pipeline::daemons::analysis
 
 =back
 
@@ -77,10 +87,11 @@ fire off analysis pipeline for each
 =head1 AUTHOR
 
 Andy Brown
+Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2015 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/npg_pipeline/base.pm
+++ b/lib/npg_pipeline/base.pm
@@ -503,7 +503,7 @@ sub _read_config {
   if ( scalar @{ $config } ) {
     $config = $config->[0]->{ $path };
   }
- 
+
   return $config;
 }
 

--- a/lib/npg_pipeline/base.pm
+++ b/lib/npg_pipeline/base.pm
@@ -12,6 +12,8 @@ use Cwd qw(abs_path);
 use File::Slurp;
 use FindBin qw($Bin);
 use Readonly;
+use Try::Tiny;
+
 use npg_tracking::util::abs_path qw(network_abs_path);
 
 our $VERSION = '0';
@@ -396,7 +398,16 @@ around 'function_list' => sub {
 =head2 function_list_conf
 
 =cut
-has 'function_list_conf' => (
+
+=head2 study_analysis_conf
+
+Returns an array ref of study analysis configuration details. If the configuration file is not
+found or is not readable, an empty array is returned.
+
+=cut 
+
+has [qw { function_list_conf
+          study_analysis_conf } ] => (
   isa        => q{ArrayRef},
   is         => q{ro},
   lazy_build => 1,
@@ -406,6 +417,25 @@ has 'function_list_conf' => (
 sub _build_function_list_conf {
   my ( $self ) = @_;
   return $self->_read_config( $self->function_list );
+}
+sub _build_study_analysis_conf {
+  my ( $self ) = @_;
+
+  my $config = [];
+  my $path;
+  try {
+    $path = $self->_conf_file_path( $self->_conf_file_path(q{study_analysis.yml}) );
+  } catch {
+    if ($self->verbose) {
+      $self->log(qq[Failed to retrieve study analysis configuration: $_]);
+    }
+  };
+
+  if ($path) {
+    $config = $self->_read_config($path);
+  }
+
+  return $config;
 }
 
 =head2 general_values_conf
@@ -445,7 +475,6 @@ sub _build_parallelisation_conf {
   my ( $self ) = @_;
   return $self->_read_config( $self->_conf_file_path(q{parallelisation.yml}) );
 }
-
 sub _build_daemon_conf { # this file is optional
   my ( $self ) = @_;
   my $path = abs_path( catfile($self->conf_path(), 'daemon.ini') );
@@ -474,7 +503,7 @@ sub _read_config {
   if ( scalar @{ $config } ) {
     $config = $config->[0]->{ $path };
   }
-
+ 
   return $config;
 }
 

--- a/lib/npg_pipeline/daemons/analysis.pm
+++ b/lib/npg_pipeline/daemons/analysis.pm
@@ -1,0 +1,186 @@
+package npg_pipeline::daemons::analysis;
+
+use Moose;
+use Moose::Meta::Class;
+use Try::Tiny;
+use Readonly;
+
+use npg_tracking::illumina::run::folder::location;
+use npg_tracking::illumina::run::short_info;
+use npg_tracking::util::abs_path qw/abs_path/;
+
+extends qw{npg_pipeline::daemons::base};
+
+our $VERSION = '0';
+
+Readonly::Scalar my $PIPELINE_SCRIPT        => q{npg_pipeline_central};
+Readonly::Scalar my $DEFAULT_JOB_PRIORITY   => 50;
+Readonly::Scalar my $RAPID_RUN_JOB_PRIORITY => 60;
+Readonly::Scalar my $ANALYSIS_PENDING       => q{analysis pending};
+
+sub _build_pipeline_script_name {
+  return $PIPELINE_SCRIPT;
+}
+
+sub run {
+  my $self = shift;
+
+  foreach my $run ($self->runs_with_status($ANALYSIS_PENDING)) {
+    try {
+      if ( $self->staging_host_match($run->folder_path_glob)) {
+        $self->_process_one_run($run);
+      }
+    } catch {
+      $self->logger->warn(
+        join q[ ], 'Error processing run', $run->id_run(), q[:], $_ );
+    };
+  }
+
+  return;
+}
+
+sub _process_one_run {
+  my ($self, $run) = @_;
+
+  my $id_run = $run->id_run();
+  $self->logger->info(qq{Considering run $id_run});
+  if ($self->seen->{$id_run}) {
+    $self->ogger->info(qq{Already seen run $id_run, skipping...});
+    return;
+  }
+
+  my $arg_refs = $self->check_lims_link($run);
+  $arg_refs->{'script'} = $self->pipeline_script_name;
+
+  $arg_refs->{'job_priority'} = $run->run_lanes->count <= 2 ?
+    $RAPID_RUN_JOB_PRIORITY : $DEFAULT_JOB_PRIORITY;
+  my $inherited_priority = $run->priority;
+  if ($inherited_priority > 0) { #not sure we curate what we get from LIMs
+    $arg_refs->{'job_priority'} += $inherited_priority;
+  }
+
+  $arg_refs->{'rf_path'} = $self->_runfolder_path($id_run);
+
+  $self->run_command( $id_run, $self->_generate_command( $arg_refs ) );
+
+  return;
+}
+
+sub _runfolder_path {
+  my ($self, $id_run) = @_;
+
+  my $class =  Moose::Meta::Class->create_anon_class(
+    roles => [ qw/npg_tracking::illumina::run::folder::location
+                  npg_tracking::illumina::run::short_info/ ]
+  );
+  $class->add_attribute(q(npg_tracking_schema),
+                        {isa => 'npg_tracking::Schema', is=>q(ro)});
+
+  my $path = $class->new_object(
+    npg_tracking_schema => $self->npg_tracking_schema,
+    id_run              => $id_run,
+  )->runfolder_path;
+
+  return abs_path($path);
+}
+
+sub _generate_command {
+  my ( $self, $arg_refs ) = @_;
+
+  my $cmd = sprintf '%s --verbose --job_priority %i --runfolder_path %s',
+             $self->pipeline_script_name,
+             $arg_refs->{'job_priority'},
+             $arg_refs->{'rf_path'};
+
+  if ( $arg_refs->{'gclp'} ) {
+    $self->logger->info('GCLP run');
+    $cmd .= ' --function_list gclp --force_p4';
+  } elsif ( $arg_refs->{'id'} ) {
+    $self->logger->info('Non-GCLP run');
+    $cmd .= ' --id_flowcell_lims ' . $arg_refs->{'id'};
+  }
+
+  my $path = join q[:], $self->local_path(), $ENV{'PATH'};
+  my $prefix = $self->daemon_conf()->{'command_prefix'};
+  if (not defined $prefix) { $prefix=q(); }
+  $cmd = qq{export PATH=$path; $prefix$cmd};
+  return $cmd;
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+1;
+
+__END__
+
+=head1 NAME
+
+npg_pipeline::daemons::analysis
+
+=head1 SYNOPSIS
+
+  my $runner = npg_pipeline::daemons::analysis->new();
+  $runner->run();
+
+=head1 DESCRIPTION
+
+Runner for the analysis pipeline. The run method can be invoked
+repeatedly thus creating a daemon that continiously monitors
+the runs and invokes the analysis pipeline.
+
+=head1 SUBROUTINES/METHODS
+
+=head2 run
+
+Invokes the analysis pipeline script for runs with 'analysis pending'
+status. Runs for which LIMS data are not available are skipped. 
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item Try::Tiny
+
+=item Readonly
+
+=item Moose::Meta::Class
+
+=item npg_tracking::illumina::run::folder::location
+
+=item npg_tracking::illumina::run::short_info
+
+=item use npg_tracking::util::abs_path
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Andy Brown
+Marina Gourtovaia
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2015 Genome Research Ltd.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/lib/npg_pipeline/daemons/archival_runner.pm
+++ b/lib/npg_pipeline/daemons/archival_runner.pm
@@ -1,50 +1,47 @@
 package npg_pipeline::daemons::archival_runner;
 
 use Moose;
-use Carp;
-use English qw{-no_match_vars};
 use Readonly;
+use Try::Tiny;
 
-extends qw{npg_pipeline::daemons::harold_analysis_runner};
+extends qw{npg_pipeline::daemons::base};
 
 our $VERSION = '0';
 
-Readonly::Scalar our $POST_QC_REVIEW_SCRIPT       => q{npg_pipeline_post_qc_review};
-Readonly::Scalar our $ARCHIVAL_PENDING            => q{archival pending};
+Readonly::Scalar our $POST_QC_REVIEW_SCRIPT => q{npg_pipeline_post_qc_review};
+Readonly::Scalar our $ARCHIVAL_PENDING      => q{archival pending};
 
 sub _build_pipeline_script_name {
   return $POST_QC_REVIEW_SCRIPT;
 }
 
 sub run {
-  my ($self) = @_;
-  $self->log(q{Archival daemon running...});
+  my $self = shift;
+
   foreach my $run ($self->runs_with_status($ARCHIVAL_PENDING)) {
     my $id_run = $run->id_run();
-    eval {
-      $self->log(qq{Considering run $id_run});
+    try {
+      $self->logger->info(qq{Considering run $id_run});
       if ($self->seen->{$id_run}) {
-        $self->log(qq{Already seen run $id_run, skipping...});
-        next;
+        $self->logger->info(qq{Already seen run $id_run, skipping...});
+      } else {
+        if ( $self->staging_host_match($run->folder_path_glob)) {
+          my $lims = $self->check_lims_link($run);
+          $self->run_command($id_run, $self->_generate_command($id_run, $lims->{'gclp'}));
+        }
       }
-      if ( $self->staging_host_match($run->folder_path_glob)) {
-        my $lims = $self->check_lims_link($run);
-        $self->run_command($id_run, $self->_generate_command($id_run, $lims->{'gclp'}));
-      }
-      1;
-    } or do {
-      $self->log('Problems to process one run ' . $run->id_run() );
-      $self->log($EVAL_ERROR);
-      next;
+    } catch {
+      $self->logger->error("Error processing run ${id_run}: $_");
     };
   }
-  return 1;
+
+  return;
 }
 
 sub _generate_command {
   my ($self, $id_run, $gclp) = @_;
 
-  $self->log($gclp ? 'GCLP run' : 'Non-GCLP run');
+  $self->logger->info($gclp ? 'GCLP run' : 'Non-GCLP run');
 
   my $cmd = $self->pipeline_script_name();
   $cmd = $cmd . ($gclp ? q{ --function_list post_qc_review_gclp} : q());
@@ -60,6 +57,7 @@ sub _generate_command {
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;
+
 __END__
 
 =head1 NAME
@@ -73,11 +71,14 @@ npg_pipeline::daemons::archival_runner
 
 =head1 DESCRIPTION
 
-This module interrogates the npg database for runs with a status of archival pending, and then runs the npg_pipeline_post_qc_review script on each of them
+Daemon for invoking the archival pipeline.
 
 =head1 SUBROUTINES/METHODS
 
-=head2 run - the only method and the only one you need. It does everything.
+=head2 run
+
+Continiously monitors run statuses. Invokes the archival pipeline for
+runs with a status 'archival pending'.
 
 =head1 DIAGNOSTICS
 
@@ -89,9 +90,7 @@ This module interrogates the npg database for runs with a status of archival pen
 
 =item Moose
 
-=item Carp
-
-=item English -no_match_vars
+=item Try::Tiny
 
 =item Readonly
 
@@ -108,7 +107,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Ltd.
+Copyright (C) 2015 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/t/10-base.t
+++ b/t/10-base.t
@@ -1,13 +1,14 @@
 use strict;
 use warnings;
-use Test::More tests => 80;
+use Test::More tests => 82;
 use Test::Exception;
-use t::util;
 use File::Temp qw(tempdir tempfile);
 use File::Copy qw(cp);
 use Cwd;
 use Sys::Filesystem::MountPoint qw(path_to_mount_point);
 use Sys::Hostname;
+
+use t::util;
 use t::dbic_util;
 
 use_ok(q{npg_pipeline::base});
@@ -50,6 +51,13 @@ use_ok(q{npg_pipeline::base});
   } ) {
     isa_ok( $base->$config_group(), q{HASH}, q{$} . qq{base->$config_group} );
   }
+
+  my $tempdir = tempdir( CLEANUP => 1 );
+  $base = npg_pipeline::base->new(conf_path => $tempdir, verbose => 0);
+  is_deeply($base->study_analysis_conf(), [],
+    'no study analysis config file - empty array returned');
+  $base = npg_pipeline::base->new(conf_path => 't/data/study_analysis_conf');
+  isa_ok($base->study_analysis_conf(), 'ARRAY', 'array of study configurations');
 }
 
 {

--- a/t/50-npg_pipeline-daemon-analysis.t
+++ b/t/50-npg_pipeline-daemon-analysis.t
@@ -1,18 +1,24 @@
 use strict;
 use warnings;
-use Test::More tests => 55;
+use Test::More tests => 51;
 use Test::Exception;
 use Cwd;
 use File::Path qw/make_path/;
 use List::MoreUtils qw{any};
+use Log::Log4perl qw(:easy);
+
 use t::util;
 use t::dbic_util;
 
-use_ok('npg_pipeline::daemons::harold_analysis_runner');
+Log::Log4perl->easy_init($ERROR);
+
+my $package = 'npg_pipeline::daemons::analysis';
+
+use_ok($package);
 
 my $script_name = q[npg_pipeline_central];
-is (npg_pipeline::daemons::harold_analysis_runner->pipeline_script_name(),
-            $script_name, 'pipeline script name correct'); 
+is ($package->pipeline_script_name(),
+    $script_name, 'pipeline script name correct'); 
 
 my $util = t::util->new();
 my $temp_directory = $util->temp_directory();
@@ -26,7 +32,8 @@ my $dbic_util = t::dbic_util->new();
 my $schema = $dbic_util->test_schema();
 my $test_run = $schema->resultset(q[Run])->find(1234);
 $test_run->update_run_status('analysis pending', 'pipeline',);
-is($test_run->current_run_status_description, 'analysis pending', 'test run is analysis pending');
+is($test_run->current_run_status_description,
+  'analysis pending', 'test run is analysis pending');
 
 my $folder_path_glob = $test_run->folder_path_glob();
 like($folder_path_glob, qr/\/sf33\//, 'folder path glob correct for a test run');
@@ -37,7 +44,7 @@ my $rf_path = '/some/path';
 
 package test_analysis_runner;
 use Moose;
-extends 'npg_pipeline::daemons::harold_analysis_runner';
+extends 'npg_pipeline::daemons::analysis';
 sub check_lims_link{ return {'id' => 0}; }
 sub _runfolder_path { return '/some/path' };
 
@@ -50,23 +57,23 @@ package main;
   my $path32 = '/{export,nfs}/sf32/ILorHSany_sf32/*/';
   my $runner;
   lives_ok { $runner = test_analysis_runner->new(
-      log_file_path        => $temp_directory,
-      log_file_name       => q{npg_pipeline_daemon.log} ,
       npg_tracking_schema => $schema,
   ) } q{object creation ok};
   isa_ok($runner, q{test_analysis_runner}, q{$runner});
-  
+
+  my $command_start = 'npg_pipeline_central --verbose --job_priority 50 --runfolder_path';  
+
   like($runner->_generate_command( {
     rf_path      => $rf_path,
     job_priority => 50,
-  } ), qr/npg_pipeline_central --verbose --job_priority 50 --runfolder_path $rf_path/,
+  } ), qr/$command_start $rf_path/,
     q{generated command is correct});
 
   like($runner->_generate_command( {
     rf_path      => $rf_path,
     job_priority => 50,
     gclp         => 1,
-  } ), qr/npg_pipeline_central --verbose --job_priority 50 --runfolder_path $rf_path --function_list gclp --force_p4/,
+  } ), qr/$command_start $rf_path --function_list gclp --force_p4/,
     q{generated command is correct});
 
   like($runner->_generate_command( {
@@ -74,9 +81,8 @@ package main;
     job_priority => 50,
     gclp         => 1,
     id           => 22,
-  } ), qr/npg_pipeline_central --verbose --job_priority 50 --runfolder_path $rf_path --function_list gclp --force_p4/,
+  } ), qr/$command_start $rf_path --function_list gclp --force_p4/,
     q{generated command is correct});
-
 
   ok($runner->green_host,'running on a host in a green datacentre');
   ok($runner->staging_host_match($path49), 'staging matches host');
@@ -84,47 +90,44 @@ package main;
   throws_ok {$runner->staging_host_match()}
     qr/Need folder_path_glob to decide whether the run folder and the daemon host are co-located/,
     'error if folder_path_glob is not defined';
-  ok(!$runner->staging_host_match($folder_path_glob), 'staging does not match host for a test run');
+  ok(!$runner->staging_host_match($folder_path_glob),
+    'staging does not match host for a test run');
   
   $schema->resultset(q[Run])->find(2)->update_run_status('analysis pending', 'pipeline',);
   $schema->resultset(q[Run])->find(3)->update_run_status('analysis pending', 'pipeline',);
   my @test_runs = ();
-  lives_ok { @test_runs = $runner->runs_with_status('analysis pending') } 'can get runs with analysys pending status';
+  lives_ok { @test_runs = $runner->runs_with_status('analysis pending') }
+    'can get runs with analysys pending status';
   ok(scalar @test_runs >= 3, 'at least three runs are analysis pending');
   foreach my $id (qw/2 3 1234/) {
-    ok((any {$_->id_run == $id} @test_runs), "run $id correctly identified as analysis pending");
+    ok((any {$_->id_run == $id} @test_runs),
+      "run $id correctly identified as analysis pending");
   }
-
 
   $runner = test_analysis_runner->new(
       pipeline_script_name => '/bin/true',
-      log_file_path        => $temp_directory,
-      log_file_name        => q{npg_pipeline_daemon.log} ,
       npg_tracking_schema  => $schema,
   );
   lives_ok { $runner->run(); } q{no croak on $runner->run()};
 
   local $ENV{PATH} = join q[:], $current_dir.'/t/bin/red', $ENV{PATH};
   lives_ok { $runner = test_analysis_runner->new(
-      log_file_path => $temp_directory,
-      log_file_name => q{npg_pipeline_daemon.log} ,
       npg_tracking_schema => $schema,
   ) } q{object creation ok};
   like($runner->_generate_command( {
     rf_path      => $rf_path,
     job_priority => 50,
     id           => 56,
-  } ), qr/npg_pipeline_central --verbose --job_priority 50 --runfolder_path $rf_path --id_flowcell_lims 56/,
+  } ), qr/$command_start $rf_path --id_flowcell_lims 56/,
     q{generated command is correct});
   ok(!$runner->green_host, 'host is not in green datacentre');
   ok(!$runner->staging_host_match($path49), 'staging does not match host');
   ok($runner->staging_host_match($path32), 'staging matches host');
-  ok($runner->staging_host_match($folder_path_glob), 'staging matches host for a test run');
+  ok($runner->staging_host_match($folder_path_glob),
+    'staging matches host for a test run');
 
   local $ENV{PATH} = join q[:], $current_dir.'/t/bin/dodo', $ENV{PATH};
   $runner = test_analysis_runner->new(
-      log_file_path => $temp_directory,
-      log_file_name => q{npg_pipeline_daemon.log} ,
       npg_tracking_schema => $schema,
   );
   ok(!$runner->green_host, 'host is not in green datacentre');
@@ -134,11 +137,10 @@ package main;
   local $ENV{PATH} = join q[:], $current_dir.'/t/bin/red', $ENV{PATH};
   my $runner = test_analysis_runner->new(
     pipeline_script_name => '/bin/true',
-    log_file_path        => $temp_directory,
-    log_file_name        => q{npg_pipeline_daemon.log} ,
     npg_tracking_schema  => $schema,
   );
-  ok($runner->staging_host_match($folder_path_glob), 'staging matches host for a test run');
+  ok($runner->staging_host_match($folder_path_glob),
+    'staging matches host for a test run');
 
   lives_ok {
     $runner->run();
@@ -153,9 +155,10 @@ package main;
 
 package test_analysis_anotherrunner;
 use Moose;
-extends 'npg_pipeline::daemons::harold_analysis_runner';
-sub check_lims_link{ return {'id' => -1}; }
-sub _runfolder_path { return '/some/path' };
+use Carp;
+extends 'npg_pipeline::daemons::analysis';
+sub check_lims_link{ croak 'No LIMs link'; }
+sub _runfolder_path { return '/some/path'; }
 
 ########test class definition end########
 
@@ -164,13 +167,12 @@ package main;
   local $ENV{PATH} = join q[:], $current_dir.'/t/bin/red', $ENV{PATH};
   my $runner = test_analysis_anotherrunner->new(
     pipeline_script_name => '/bin/true',
-    log_file_path        => $temp_directory,
-    log_file_name        => q{npg_pipeline_daemon.log} ,
     npg_tracking_schema  => $schema,
   );
 
   lives_ok { $runner->run(); } 'one run is processed';
-  is(scalar keys %{$runner->seen}, 0, 'no lims link - run is not listed as seen');
+  is(scalar keys %{$runner->seen}, 0,
+    'no lims link - run is not listed as seen');
 }
 
 {
@@ -178,9 +180,7 @@ package main;
   my $fc_row = $wh_schema->resultset('IseqFlowcell')->search()->next;
 
   my $runner;
-  lives_ok { $runner = npg_pipeline::daemons::harold_analysis_runner->new(
-               log_file_path       => $temp_directory,
-               log_file_name       => q{npg_pipeline_daemon.log} ,
+  lives_ok { $runner = $package->new(
                npg_tracking_schema => $schema,
                iseq_flowcell       => $wh_schema->resultset('IseqFlowcell')
              );
@@ -189,7 +189,7 @@ package main;
   my $fc = 'dummy_flowcell1';
   is ($test_run->flowcell_id, $fc, 'test prereq. - tracking flowcell id');
   is ($test_run->batch_id, 55, 'test prereq. - tracking batch id');
-  is ($wh_schema->resultset('IseqFlowcell')->search('flowcell_barcode' => $fc )->count,
+  is ($wh_schema->resultset('IseqFlowcell')->search({'flowcell_barcode' => $fc})->count,
     0, 'test prereq. - no rows with this barcode in the lims table');
 
   my $lims_data = $runner->check_lims_link($test_run);
@@ -219,19 +219,15 @@ package main;
 
   $fc_row->update({flowcell_barcode => 'some value'});
 
-  $lims_data = $runner->check_lims_link($test_run);
-  is ($lims_data->{'id'}, -1,
-    'correct return value when neither batch id nor flowcell barcode can be used');
-  is ($lims_data->{'message'}, 'No matching flowcell LIMs record is found');
-  ok (!exists $lims_data->{'gclp'}, 'gclp flag is not set');
+  throws_ok { $runner->check_lims_link($test_run) }
+    qr/No matching flowcell LIMs record is found/,
+    'no lims record - error';
 
   $test_run->update({flowcell_id => undef,});
   ok (!defined $test_run->batch_id, 'test prereq. - tracking flowcell id undefined');
-  $lims_data = $runner->check_lims_link($test_run);
-  is ($lims_data->{'id'}, -1,
-    'correct return value when tracking does not have flowcell barcode');
-  is ($lims_data->{'message'}, 'No flowcell barcode', 'correct message');
-  ok (!exists $lims_data->{'gclp'}, 'gclp flag is not set');
+  throws_ok { $runner->check_lims_link($test_run) }
+    qr/No flowcell barcode/,
+    'no barcode in tracking db - error';
 }
 
 {
@@ -244,9 +240,7 @@ package main;
   $row->set_tag('pipeline','staging');
   $row->update({folder_path_glob => $temp . q[/sf33/ILorHSany_sf33/*/], folder_name => $name});
 
-  my $runner = npg_pipeline::daemons::harold_analysis_runner->new(
-               log_file_path       => $temp_directory,
-               log_file_name       => q{npg_pipeline_daemon.log} ,
+  my $runner = $package->new(
                npg_tracking_schema => $schema,
              );
   is( $runner->_runfolder_path(1234), $rf, 'runfolder path is correct');

--- a/t/50-npg_pipeline-daemon-archival.t
+++ b/t/50-npg_pipeline-daemon-archival.t
@@ -4,12 +4,17 @@ use Test::More tests => 19;
 use Test::Exception;
 use Cwd;
 use List::MoreUtils qw{any};
+use Log::Log4perl qw(:easy);
+
 use t::dbic_util;
 use t::util;
 
 BEGIN {
   use_ok('npg_pipeline::daemons::archival_runner');
 }
+
+Log::Log4perl->easy_init($ERROR);
+
 my $script_name = q[npg_pipeline_post_qc_review];
 is (npg_pipeline::daemons::archival_runner->pipeline_script_name(),
             $script_name, 'pipeline script name correct'); 

--- a/t/data/study_analysis_conf/study_analysis.yml
+++ b/t/data/study_analysis_conf/study_analysis.yml
@@ -1,0 +1,15 @@
+# Study analysis environment
+# for gseq farm
+---
+- lims_id: SQSCP
+  is_gclp: 0
+  software: 20151123
+  study_id: 4567
+- lims_id: C_GCLPVL
+  is_gclp: 1
+  software: 20151023
+  study_id: 4567
+- lims_id: C_GCLP
+  is_gclp: 1
+  software: 20160113
+  study_id: A345


### PR DESCRIPTION
Previminary work for study-specific analysis environment. A common parent class for pipeline daemons is introduced. Previously the archival daemon inherited from the analysis one. Since the analysis daemon will be extended, it's better to have common functionality in a parent module. 

Extract from Changes file
----------------------------------
- require minimum version 5.10 for perl
 - add study analysis configuration accessor
 - simpler name for the archival daemon module
 - parent class for pipeline daemons
 - consistent behaviour of the archival and analysis daemons
   when LIMs data are not available in the ml warehouse -
   the run is skipped
 - Log::Log4perl logger is used in pipeline daemons