### PR TITLE
purge carriage returns (as well line feeds) from study descriptions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 LIST OF CHANGES
 ---------------
 
+ - purge carriage returns (as well line feeds) from study descriptions for RG header
+   records (xml lims driver has previously done this as part of XML parsing)
  - require minimum version 5.10 for perl
  - add study analysis configuration accessor
  - simpler name for the archival daemon module

--- a/lib/npg_pipeline/roles/business/base.pm
+++ b/lib/npg_pipeline/roles/business/base.pm
@@ -354,6 +354,7 @@ sub get_study_library_sample_names {
      my $study_description = $al->is_control ? 'SPIKED_CONTROL' : $al->study_description;
      if( $study_name ){
         if( $study_description ){
+           $study_description =~ s/\r//gmxs;
            $study_description =~ s/\n/\ /gmxs;
            $study_description =~ s/\t/\ /gmxs;
            $study_name .= q{: }.$study_description;


### PR DESCRIPTION
for RG header records (xml lims driver has previously done this as part of XML parsing)