### PR TITLE
study-specific software stack for the analysis pipeline

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES
 ---------------
+ 
+ - study-specific software stack for the analysis pipeline
 
 release 50.2
  - names of the pipeline daemon modules and scripts harmonised

--- a/lib/npg_pipeline/base.pm
+++ b/lib/npg_pipeline/base.pm
@@ -656,9 +656,7 @@ __END__
 
 =item File::Slurp
 
-=item File::Spec::Functions 
-
-=item FindBin qw($Bin)
+=item File::Spec::Functions
 
 =item Sys::Filesystem::MountPoint 
 

--- a/lib/npg_pipeline/daemon.pm
+++ b/lib/npg_pipeline/daemon.pm
@@ -116,6 +116,9 @@ has 'mlwh_schema' => (
   metaclass  => 'NoGetopt',
   lazy_build => 1,
 );
+sub _build_mlwh_schema {
+  return WTSI::DNAP::Warehouse::Schema->connect();
+}
 
 has 'iseq_flowcell' => (
   isa        => q{DBIx::Class::ResultSet},
@@ -207,7 +210,8 @@ sub check_lims_link {
 
   my @studies = ();
   if (!$lims->{'qc_run'}) {
-    @studies = sort uniq map { $_->study_id } grep { !$_->is_control } @fcell_rows;
+    @studies = uniq map { $_->study_id } grep { !$_->is_control } @fcell_rows;
+    @studies = sort @studies;
   }
   $lims->{'studies'} = \@studies;
 

--- a/lib/npg_pipeline/daemon/analysis.pm
+++ b/lib/npg_pipeline/daemon/analysis.pm
@@ -46,6 +46,8 @@ sub _build_study_analysis_conf {
 sub run {
   my $self = shift;
 
+  $self->study_analysis_conf();
+
   foreach my $run ($self->runs_with_status($ANALYSIS_PENDING)) {
     try {
       if ( $self->staging_host_match($run->folder_path_glob)) {
@@ -93,7 +95,7 @@ sub _software_bundle {
   if (!defined $is_gclp_run) {
     croak 'GCLP flag is not defined';
   }
-  if (!$studies || !@{$studies}) {
+  if (!$studies) {
     croak 'Study ids are missing';
   }
 
@@ -115,7 +117,7 @@ sub _software_bundle {
     croak qq{Directory '$software_dir' does not exist};
   }
 
-  return abs_path($software_dir);
+  return $software_dir ? abs_path($software_dir) : q[];
 }
 
 ##########

--- a/lib/npg_pipeline/pluggable.pm
+++ b/lib/npg_pipeline/pluggable.pm
@@ -355,7 +355,16 @@ sub schedule_functions {
 
 =cut
 sub prepare {
-  return 1;
+  my $self = shift;
+  if ($self->verbose) {
+    my $s = '***************************************************';
+    $self->log("\n" . $s);
+    foreach my $name (qw/PATH CLASSPATH PERL5LIB/) {
+      $self->log(sprintf '*** %s: %s', $name, $ENV{$name});
+    }
+    $self->log($s . "\n");
+  }
+  return;
 }
 
 =head2 main
@@ -428,7 +437,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Ltd
+Copyright (C) 2016 Genome Research Ltd
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/npg_pipeline/roles/accessor.pm
+++ b/lib/npg_pipeline/roles/accessor.pm
@@ -8,6 +8,8 @@ use FindBin qw($Bin);
 use File::Spec::Functions qw(catfile);
 use Readonly;
 
+use npg_tracking::util::abs_path qw/abs_path/;
+
 our $VERSION = '0';
 
 Readonly::Scalar my $CONF_DIR => q{data/config_files};
@@ -28,6 +30,22 @@ A Moose role providing accessors for pipeline's sources of information.
 
 =head1 SUBROUTINES/METHODS
 
+=head2 local_bin
+
+Absolute path to directory containing the currently running script.
+
+=cut
+
+has q{local_bin} => (
+  isa           => q{Str},
+  is            => q{ro},
+  lazy_build    => 1,
+  documentation => q{abs path to directory containing the currently running script},
+);
+sub _build_local_bin {
+  return abs_path($Bin);
+}
+
 =head2 conf_path
 
 Path of the directory with the pipeline's configuration files.
@@ -39,11 +57,11 @@ has q{conf_path} => (
   isa           => q{Str},
   is            => q{ro},
   lazy_build    => 1,
-  documentation => q{full path to directory containing config files},
+  documentation => q{a full path to directory containing config files},
 );
 sub _build_conf_path {
   my $self = shift;
-  return "$Bin/../$CONF_DIR";
+  return $self->local_bin . "/../$CONF_DIR";
 }
 
 =head2 conf_file_path
@@ -105,6 +123,8 @@ __END__
 =item FindBin
 
 =item Readonly
+
+=item npg_tracking::util::abs_path
 
 =back
 

--- a/t/50-npg_pipeline-daemon-analysis.t
+++ b/t/50-npg_pipeline-daemon-analysis.t
@@ -1,11 +1,12 @@
 use strict;
 use warnings;
-use Test::More tests => 62;
+use Test::More tests => 11;
 use Test::Exception;
 use Cwd;
 use File::Path qw{ make_path };
 use List::MoreUtils qw{ any };
 use Log::Log4perl qw{ :easy };
+use English qw{ -no_match_vars };
 
 use t::util;
 use t::dbic_util;
@@ -51,14 +52,16 @@ sub runfolder_path4run { return '/some/path' };
 
 package main;
 
-{
+subtest 'staging host matching' => sub {
+  plan tests => 26;
+
   my $path49 = '/{export,nfs}/sf49/ILorHSany_sf49/*/';
   my $path32 = '/{export,nfs}/sf32/ILorHSany_sf32/*/';
   my $runner;
   lives_ok { $runner = test_analysis_runner->new(
       npg_tracking_schema => $schema,
       iseq_flowcell       => $wh_schema->resultset('IseqFlowcell')
-  ) } q{object creation ok};
+  )} q{object creation ok};
   isa_ok($runner, q{test_analysis_runner}, q{$runner});
   is($runner->pipeline_script_name, $script_name, 'script name');
   ok(!$runner->dry_run, 'dry_run mode switched off by default');
@@ -68,8 +71,7 @@ package main;
   throws_ok { $runner->_generate_command( {
                      rf_path      => $rf_path,
                      job_priority => 50,
-                                       } )
-            } qr/Lims flowcell id is missing/,
+  }) } qr/Lims flowcell id is missing/,
     'non-gclp run and lims flowcell id is missing - error';
 
   like($runner->_generate_command( {
@@ -91,7 +93,7 @@ package main;
     job_priority => 50,
     gclp         => 1,
     id           => 22,
-  } ), qr/$command_start $rf_path --function_list gclp/,
+  }), qr/$command_start $rf_path --function_list gclp/,
     q{generated command is correct});
 
   ok($runner->green_host,'running on a host in a green datacentre');
@@ -125,12 +127,12 @@ package main;
   lives_ok { $runner = test_analysis_runner->new(
       npg_tracking_schema => $schema,
       iseq_flowcell       => $wh_schema->resultset('IseqFlowcell')
-  ) } q{object creation ok};
+  )} q{object creation ok};
   like($runner->_generate_command( {
     rf_path      => $rf_path,
     job_priority => 50,
     id           => 56,
-  } ), qr/$command_start $rf_path --id_flowcell_lims 56/,
+  }), qr/$command_start $rf_path --id_flowcell_lims 56/,
     q{generated command is correct});
   ok(!$runner->green_host, 'host is not in green datacentre');
   ok(!$runner->staging_host_match($path49), 'staging does not match host');
@@ -144,7 +146,7 @@ package main;
       iseq_flowcell       => $wh_schema->resultset('IseqFlowcell')
   );
   ok(!$runner->green_host, 'host is not in green datacentre');
-}
+};
 
 ########test class definition start########
 
@@ -158,7 +160,10 @@ sub runfolder_path4run { return '/some/path'; }
 ########test class definition end########
 
 package main;
-{
+
+subtest 'failure to retrive lims data' => sub {
+  plan tests => 2;
+
   local $ENV{PATH} = join q[:], $current_dir.'/t/bin/red', $ENV{PATH};
   my $runner = test_analysis_anotherrunner->new(
     pipeline_script_name => '/bin/true',
@@ -169,15 +174,16 @@ package main;
   lives_ok { $runner->run(); } 'one run is processed';
   is(scalar keys %{$runner->seen}, 0,
     'no lims link - run is not listed as seen');
-}
+};
 
-{
+subtest 'retrieve lims data' => sub {
+  plan tests => 25;
+
   my $runner;
   lives_ok { $runner = $package->new(
                npg_tracking_schema => $schema,
-               iseq_flowcell       => $wh_schema->resultset('IseqFlowcell')
-             );
-  } 'object created';
+               mlwh_schema         => $wh_schema,
+  )} 'object created';
 
   $test_run->update({'flowcell_id' => undef});
   throws_ok {$runner->check_lims_link($test_run)}
@@ -197,6 +203,7 @@ package main;
   is ($lims_data->{'id'}, '1234567891234', 'lims id');
   is ($lims_data->{'qc_run'}, 1, 'is qc run');
   ok(!$lims_data->{'gclp'}, 'gclp flag is false');
+  is_deeply($lims_data->{'studies'}, [], 'studies not retrieved');
 
   $test_run->update({'batch_id' => 55});
   is ($wh_schema->resultset('IseqFlowcell')->search({'flowcell_barcode' => $fc})->count,
@@ -206,7 +213,9 @@ package main;
     'non-qc run not in mlwh - error';
 
   $test_run->update({'batch_id' => undef});
-  my $fc_row = $wh_schema->resultset('IseqFlowcell')->search()->next;
+  my $rs = $wh_schema->resultset('IseqFlowcell')->search();
+  $rs->next;
+  my $fc_row = $rs->next;
   $fc_row->update({'flowcell_barcode' => $fc});
   is ($wh_schema->resultset('IseqFlowcell')->search({'flowcell_barcode' => $fc})->count,
     1, 'test prereq. - one row with this barcode in the lims table');
@@ -216,12 +225,14 @@ package main;
   is ($lims_data->{'id'}, undef, 'lims id is undefined');
   ok(!$lims_data->{'gclp'}, 'gclp flag is false');
   is ($lims_data->{'qc_run'}, undef, 'qc run flag is not set');
+  is(join(q[:], @{$lims_data->{'studies'}}), '2967', 'studies retrieved');
 
   $fc_row->update({'id_lims' => 'C_GCLP'});
   $lims_data = $runner->check_lims_link($test_run);
   is ($lims_data->{'id'}, undef, 'lims id is undefined');
   is ($lims_data->{'gclp'}, 1, 'gclp flag is set to true');
   is ($lims_data->{'qc_run'}, undef, 'qc run flag is not set');
+  is(join(q[:], @{$lims_data->{'studies'}}), '2967', 'studies retrieved');
 
   $test_run->update({'batch_id' => 55});
   $fc_row->update({'id_flowcell_lims' => 55});
@@ -229,15 +240,109 @@ package main;
   is ($lims_data->{'id'}, 55, 'lims id is set');
   is ($lims_data->{'gclp'}, 1, 'gclp flag is set to true');
   is ($lims_data->{'qc_run'}, undef, 'qc run flag is not set');
+  is(join(q[:], @{$lims_data->{'studies'}}), '2967', 'studies retrieved');
 
   $fc_row->update({'id_lims' => 'SSCAPE'});
   $lims_data = $runner->check_lims_link($test_run);
   is ($lims_data->{'id'}, 55, 'lims id is set');
   ok (!$lims_data->{'gclp'}, 'gclp flag is false');
   is ($lims_data->{'qc_run'}, undef, 'qc run flag is not set');
-}
+};
 
-{
+subtest 'generate command' => sub {
+  plan tests => 2;
+
+  my $runner  = $package->new(
+               pipeline_script_name => '/bin/true',
+               npg_tracking_schema  => $schema,
+               mlwh_schema          => $wh_schema,
+  );
+  my $lims_data = $runner->check_lims_link($test_run);
+  $lims_data->{'job_priority'} = 4;
+  $lims_data->{'rf_path'} = 't';
+  $lims_data->{'software'} = q[];
+  my $original_path = $ENV{'PATH'};
+  my $perl_bin = $EXECUTABLE_NAME;
+  $perl_bin =~ s/\/perl\Z//smx;
+  my $path = join q[:], "${current_dir}/t", $perl_bin, $original_path;
+  my $command = q[/bin/true --verbose --job_priority 4 --runfolder_path t --id_flowcell_lims 55];
+  is($runner->_generate_command($lims_data),
+    qq[export PATH=${path}; $command],
+    'command without changing software bundle');
+
+  $lims_data->{'software'} = q[t/data];
+  $path = join q[:], $perl_bin, $original_path;
+  is($runner->_generate_command($lims_data),
+    qq[export PERL5LIB=t/data/lib/perl5; export CLASSPATH=t/data/jars; export PATH=t/data/bin:${path}; $command],
+    'command with software bundle');
+};
+
+subtest 'retrieve study analysis configuration' => sub {
+  plan tests => 6;
+
+  my $d = npg_pipeline::daemon::analysis->new();
+  isa_ok( $d->daemon_conf(), q{HASH}, q{$} . qq{base->daemon_conf} );
+
+  $d = npg_pipeline::daemon::analysis->new(conf_path => $temp_directory);
+  is_deeply($d->study_analysis_conf(), {},
+    'no study analysis config file - empty array returned');
+
+  $d = npg_pipeline::daemon::analysis->new(conf_path => 't/data/study_analysis_conf');
+  my $conf = $d->study_analysis_conf();
+  isa_ok($conf, 'HASH', 'HASH of study configurations');
+  is($conf->{'gclp_all_studies'}, 't/data', 'dated directory name for gclp runs');
+  is($conf->{'12345'}, 't', 'dated directory name for study 12345');
+  is($conf->{'XY345'}, '/some/dir', 'dated directory name for study 12345');
+};
+
+subtest 'get software bundle' => sub {
+  plan tests => 9;
+
+  my $runner  = $package->new(
+    pipeline_script_name => '/bin/true',
+    npg_tracking_schema  => $schema,
+    mlwh_schema          => $wh_schema,
+  );
+
+  throws_ok { $runner->_software_bundle() }
+    qr/GCLP flag is not defined/,
+    'error if gclp flag is not defined';
+  throws_ok { $runner->_software_bundle(1) }
+    qr/Study ids are missing/,
+    'error if no study array is given';
+  throws_ok { $runner->_software_bundle(1, ()) }
+    qr/Study ids are missing/,
+    'error if study array is empty';
+  throws_ok { $runner->_software_bundle(1, [qw/3/]) }
+    qr/GCLP run needs explicit software bundle/,
+    'no GCLP conf - error';
+
+  $runner  = $package->new(
+    pipeline_script_name => '/bin/true',
+    npg_tracking_schema  => $schema,
+    mlwh_schema          => $wh_schema,
+    conf_path            => 't/data/study_analysis_conf',
+  );
+
+  throws_ok { $runner->_software_bundle(0, [qw/3 12345/]) }
+    qr/Multiple software bundles for a run/,
+    'Software and no software - error';
+  throws_ok { $runner->_software_bundle(0, [qw/12345 12346/]) }
+    qr/Multiple software bundles for a run/,
+    'Multiple software bundles - error';
+  throws_ok { $runner->_software_bundle(0, [qw/XY345/]) }
+    qr/Directory \'\/some\/dir\' does not exist/,
+    'directory does not exist - error';
+
+  is($runner->_software_bundle(0, [qw/12346 12347/]),
+    "${current_dir}/t/data/cache", 'study analysis directory retrieved');
+  is($runner->_software_bundle(1, [qw/12346 12347/]),
+    "${current_dir}/t/data", 'GCLP study analysis directory retrieved');  
+};
+
+subtest 'mock continious running' => sub {
+  plan tests => 6;
+
   local $ENV{PATH} = join q[:], $current_dir.'/t/bin/red', $ENV{PATH};
   my $runner = test_analysis_runner->new(
     pipeline_script_name => '/bin/true',
@@ -269,9 +374,11 @@ package main;
   } q{no croak running (dry) through twice};
 
   is (join(q[ ],sort keys %{$runner->seen}), '1234', 'correct list of seen runs');
-}
+};
 
-{
+subtest 'compute runfolder path' => sub {
+  plan tests => 1;
+
   my $temp = t::util->new()->temp_directory();
   my $name = '150227_HS35_1234_A_HBFJ3ADXX';
   my $rf = join q[/], $temp, 'sf33/ILorHSany_sf33/outgoing', $name;
@@ -287,19 +394,6 @@ package main;
                iseq_flowcell       => $wh_schema->resultset('IseqFlowcell')
              );
   is( $runner->runfolder_path4run(1234), $rf, 'runfolder path is correct');
-}
-
-{
-
-  my $d = npg_pipeline::daemon::analysis->new();
-  isa_ok( $d->daemon_conf(), q{HASH}, q{$} . qq{base->daemon_conf} );
-
-  $d = npg_pipeline::daemon::analysis->new(conf_path => $temp_directory);
-  is_deeply($d->study_analysis_conf(), [],
-    'no study analysis config file - empty array returned');
-
-  $d = npg_pipeline::daemon::analysis->new(conf_path => 't/data/study_analysis_conf');
-  isa_ok($d->study_analysis_conf(), 'ARRAY', 'array of study configurations');
-}
+};
 
 1;

--- a/t/data/study_analysis_conf/study_analysis.yml
+++ b/t/data/study_analysis_conf/study_analysis.yml
@@ -1,15 +1,8 @@
 # Study analysis environment
 # for gseq farm
 ---
-- lims_id: SQSCP
-  is_gclp: 0
-  software: 20151123
-  study_id: 4567
-- lims_id: C_GCLPVL
-  is_gclp: 1
-  software: 20151023
-  study_id: 4567
-- lims_id: C_GCLP
-  is_gclp: 1
-  software: 20160113
-  study_id: A345
+gclp_all_studies: t/data
+12345: t
+12346: t/data/cache
+12347: t/data/cache
+XY345: /some/dir


### PR DESCRIPTION
For now, all GCLP runs default to the same software stack.
A GCLP run should have explicit software stack defined.
If no software stack is defined for a non-GCLP run, the stack the daemon is runnign from is implicitly used.
All studies in a run should either not have a software stack define or should have the same stack defined.