### PR TITLE
P4 splice prune

### DIFF
--- a/lib/npg_pipeline/archive/file/generation/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/archive/file/generation/p4_stage1_analysis.pm
@@ -388,6 +388,8 @@ sub _generate_command_params {
   }
 
 
+  my $splice_flag = q[];
+  my $prune_flag = q[];
   if($self->is_multiplexed_lane($position)) {
     if (!$tag_list_file) {
       croak 'Tag list file path should be defined for multiplexed lane ', $position;
@@ -405,9 +407,17 @@ sub _generate_command_params {
   }
   else {
     $self->log(q{P4 stage1 analysis on non-plexed lane});
-    # This should avoid using BamIndexDecoder or attempting to split a non-muliplexed lane.
-    $p4_params{bid_opt} = q[passthrough]; # don't do bamindexdecoding
-    $p4_params{fs1p} = q[final_stage1_process_nosplit.json]; # no plex splitting
+
+    # This will avoid using BamIndexDecoder or attempting to split a non-muliplexed lane.
+    $splice_flag = q[-splice_nodes '"'"'bamadapterfind:-bamcollate:'"'"'];
+    $prune_flag = q[-prune_nodes '"'"'fs1p_tee_split:__SPLIT_BAM_OUT__-'"'"'];
+
+##############
+# temporary assignment of unused parameters
+#############
+    $p4_params{bamindexdecoder_jar} = $self->_BamIndexDecoder_jar;
+    $p4_params{$bid_flag_map{q/BARCODE_FILE/}} = q[dummy_value];
+    $p4_params{$bid_flag_map{q/METRICS_FILE/}} = $full_bam_name . q{.tag_decode.metrics};
   }
 
   if(!$self->is_paired_read) {
@@ -425,6 +435,7 @@ sub _generate_command_params {
   $self->_job_args->{_commands}->{$position} = join q( ), q(bash -c '),
                            q(cd), $self->p4_stage1_errlog_paths->{$position}, q{&&},
                            q(vtfp.pl),
+                           $splice_flag, $prune_flag,
                            qq(-o run_$name_root.json),
                            q(-param_vals), (join q{/}, $self->p4_stage1_params_paths->{$position}, $name_root.q{_p4s1_pv_in.json}),
                            q(-export_param_vals), $name_root.q{_p4s1_pv_out_$}.q/{LSB_JOBID}.json/,

--- a/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
+++ b/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
@@ -239,7 +239,8 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
     #TODO: allow for an analysis genuinely without phix and where no phiX split work is wanted - especially the phix spike plex....
     #TODO: support this, and above "old school", various options in P4 analyses
     croak qq{only paired reads supported for RNA or non-consented human ($name_root)} if (not $self->is_paired_read) and ($do_rna or $nchs);
-# We should now be able to handle no target alignment
+
+# no target alignment can be handled now by p4, though --force_p4 must be used for it since default is still bam_alignment (DNA_ALIGNMENT_SCRIPT)
 #   croak qq{No alignments in bam only supported with human split ($name_root)} if (not $l->alignments_in_bam) and (not $nchs);
 #   croak qq{Reference required ($name_root)} if (not $self->_ref($l,q(fasta))) and (not $nchs);
 


### PR DESCRIPTION
use the new node splicing/pruning feature in p4 to handle unplexed lanes (p4_stage1_analysis) and "no target alignment" (seq_alignment)