### PR TITLE
Bambi i2b

### DIFF
--- a/lib/npg_pipeline/archive/file/generation/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/archive/file/generation/p4_stage1_analysis.pm
@@ -422,7 +422,7 @@ sub _generate_command_params {
   my $samtobam_slots = $self->general_values_conf()->{'p4_stage1_samtobam_slots'} || q[`npg_pipeline_job_env_to_threads --exclude -1 --divide 3`];
   my $bamsormadup_slots = $self->general_values_conf()->{'p4_stage1_bamsort_slots'} || q[`npg_pipeline_job_env_to_threads --divide 3`];
   my $bamrecompress_slots = $self->general_values_conf()->{'p4_stage1_bamrecompress_slots'} || q[`npg_pipeline_job_env_to_threads`];
-  my $i2b_implementation = $self->general_values_conf()->{'p4_stage1_i2b_implementation'} || q[bambi];
+  my $i2b_implementation = $self->general_values_conf()->{'p4_stage1_i2b_implementation'} || q[java];
   $self->_job_args->{_commands}->{$position} = join q( ), q(bash -c '),
                            q(cd), $self->p4_stage1_errlog_paths->{$position}, q{&&},
                            q(vtfp.pl),

--- a/lib/npg_pipeline/archive/file/generation/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/archive/file/generation/p4_stage1_analysis.pm
@@ -422,6 +422,7 @@ sub _generate_command_params {
   my $samtobam_slots = $self->general_values_conf()->{'p4_stage1_samtobam_slots'} || q[`npg_pipeline_job_env_to_threads --exclude -1 --divide 3`];
   my $bamsormadup_slots = $self->general_values_conf()->{'p4_stage1_bamsort_slots'} || q[`npg_pipeline_job_env_to_threads --divide 3`];
   my $bamrecompress_slots = $self->general_values_conf()->{'p4_stage1_bamrecompress_slots'} || q[`npg_pipeline_job_env_to_threads`];
+  my $i2b_implementation = $self->general_values_conf()->{'p4_stage1_i2b_implementation'} || q[bambi];
   $self->_job_args->{_commands}->{$position} = join q( ), q(bash -c '),
                            q(cd), $self->p4_stage1_errlog_paths->{$position}, q{&&},
                            q(vtfp.pl),
@@ -433,6 +434,7 @@ sub _generate_command_params {
                            qq(-keys s2b_mt_val -vals $samtobam_slots),
                            qq(-keys bamsormadup_numthreads -vals $bamsormadup_slots),
                            qq(-keys br_numthreads_val -vals $bamrecompress_slots),
+                           qq(-keys i2b_implementation -vals $i2b_implementation),
                            q{$}.q{(dirname $}.q{(dirname $}.q{(readlink -f $}.q{(which vtfp.pl))))/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json},
                            q{&&},
                            qq(viv.pl -s -x -v 3 -o viv_$name_root.log run_$name_root.json),


### PR DESCRIPTION
Allow use of bambi i2b instead of illumina2bam in p4 stage 1 analysis via general_values.ini entry "p4_stage1_i2b_implementation" (with values "java" or "bambi")