### PR TITLE
change default value LSF memory for p4_stage1

### DIFF
--- a/data/config_files/general_values.ini
+++ b/data/config_files/general_values.ini
@@ -19,6 +19,6 @@ io_resource_slots=4
 single_plex_decode_max_no_calls=6
 illumina2bam_cpu=2
 illumina2bam_memory=4000
-p4_stage1_memory=6000
+p4_stage1_memory=7000
 p4_stage1_slots=3
 qc_adapter_cpu=2


### PR DESCRIPTION

change default value for general_values.ini attribute p4_stage1_memory=7000 (up to 7GB from 6GB)
resolves #183 