### PR TITLE
Corrected post_qc_review function list

### DIFF
--- a/data/config_files/function_list_post_qc_review.yml
+++ b/data/config_files/function_list_post_qc_review.yml
@@ -1,7 +1,7 @@
 ---
 - run_archival_in_progress
 - update_ml_warehouse
-- archive_to_irods
+- archive_to_irods_ml_warehouse
 - upload_fastqcheck_to_qc_database
 - upload_illumina_analysis_to_qc_database
 - upload_auto_qc_to_qc_database


### PR DESCRIPTION
Corrected post_qc_review function list to use archive_to_irods_ml_warehouse
instead of archive_to_irods.