### PR TITLE
for tophat2 alignment, set intfile parameter

### DIFF
--- a/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
+++ b/lib/npg_pipeline/archive/file/generation/seq_alignment.pm
@@ -382,6 +382,9 @@ sub _lsf_alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity
       $p4_param_vals->{transcriptome_val} = $self->_transcriptome($l, q(tophat2))->transcriptome_index_name();
       $p4_reference_genome_index = $self->_ref($l, q(bowtie2));
     }
+    if($rna_analysis eq q[tophat2]) { # create intermediate file to prevent deadlock
+      $p4_param_vals->{align_infile_opt} = 1;
+    }
     $p4_param_vals->{alignment_method} = $rna_analysis;
     $p4_param_vals->{annotation_val} = $self->_transcriptome($l)->gtf_file();
     $p4_param_vals->{quant_method} = q[salmon];


### PR DESCRIPTION
for tophat2 alignment, set align_intfile_opt parameter to create intermediate file to prevent deadlock