### PR TITLE
update autoqc.pm to use products to construct qc jobs

### DIFF
--- a/data/config_files/function_list_central.json
+++ b/data/config_files/function_list_central.json
@@ -63,7 +63,7 @@
          },
          {
             "relation" : "dependsOn",
-            "source" : "p4_stage1_analysis",
+            "source" : "seq_alignment",
             "target" : "qc_adapter"
          },
          {

--- a/lib/npg_pipeline/function/autoqc.pm
+++ b/lib/npg_pipeline/function/autoqc.pm
@@ -192,9 +192,9 @@ sub _generate_command {
   my $cache10k_path = $dp->short_files_cache_path($archive_path);
   my $qc_out_path = $dp->qc_out_path($archive_path);
   my $bamfile_path = File::Spec->catdir($dp_archive_path, $dp->file_name(ext => 'bam'));
-  my $fq1_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '_1'));
-  my $fq2_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '_2'));
-  my $fqt_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '_t'));
+  my $fq1_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '1'));
+  my $fq2_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '2'));
+  my $fqt_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => 't'));
   my $fqc1_filepath = File::Spec->catdir($dp_archive_path, $dp->file_name(ext => 'fastqcheck', suffix => '1'));
   my $fqc2_filepath = File::Spec->catdir($dp_archive_path, $dp->file_name(ext => 'fastqcheck', suffix => '2'));
 

--- a/lib/npg_pipeline/function/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/function/p4_stage1_analysis.pm
@@ -305,7 +305,7 @@ sub _generate_command_params { ## no critic (Subroutines::ProhibitExcessComplexi
   $p4_params{md5filename} = $no_cal_path . q[/] . $id_run . q[_] . $position . q{.bam.md5}; # full name for the md5 for the spatially filtered lane-level file
   $p4_params{split_prefix} = $no_cal_path; # location for split bam files
   $p4_params{fqc1} = $fqc1_filepath;
-  $p4_params{fqc2} = $fqc1_filepath;
+  $p4_params{fqc2} = $fqc2_filepath;
 
   my $job_name = join q/_/, (q{p4_stage1}, $id_run, $position, $self->timestamp());
   $job_name = q{'} . $job_name . q{'};

--- a/lib/npg_pipeline/function/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/function/p4_stage1_analysis.pm
@@ -287,6 +287,9 @@ sub _generate_command_params { ## no critic (Subroutines::ProhibitExcessComplexi
   my $basecall_path = $self->basecall_path;
   my $no_cal_path       = $self->recalibrated_path;
   my $bam_basecall_path  = $self->bam_basecall_path;
+  my $lp_archive_path = $lane_product->path($self->archive_path);
+  my $fqc1_filepath = File::Spec->catdir($lp_archive_path, $lane_product->file_name(ext => 'fastqcheck', suffix => '1'));
+  my $fqc2_filepath = File::Spec->catdir($lp_archive_path, $lane_product->file_name(ext => 'fastqcheck', suffix => '2'));
 
   my $full_bam_name  = $bam_basecall_path . q{/}. $id_run . q{_} .$position. q{.bam};
 
@@ -301,6 +304,8 @@ sub _generate_command_params { ## no critic (Subroutines::ProhibitExcessComplexi
   $p4_params{unfiltered_cram_file} = $no_cal_path . q[/] . $id_run . q[_] . $position . q{.unfiltered.cram}; # full name for spatially unfiltered lane-level cram file
   $p4_params{md5filename} = $no_cal_path . q[/] . $id_run . q[_] . $position . q{.bam.md5}; # full name for the md5 for the spatially filtered lane-level file
   $p4_params{split_prefix} = $no_cal_path; # location for split bam files
+  $p4_params{fqc1} = $fqc1_filepath;
+  $p4_params{fqc2} = $fqc1_filepath;
 
   my $job_name = join q/_/, (q{p4_stage1}, $id_run, $position, $self->timestamp());
   $job_name = q{'} . $job_name . q{'};

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -195,9 +195,9 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   my $rpt_list = $dp->{rpt_list};
   my $bfs_input_file = $dp_archive_path . q[/] . $dp->file_name(ext => 'bam');
   my $af_input_file = $dp->file_name(ext => 'json', suffix => 'bam_alignment_filter_metrics');
-  my $fq1_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '_1'));
-  my $fq2_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '_2'));
-  my $fqt_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '_t'));
+  my $fq1_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '1'));
+  my $fq2_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => '2'));
+  my $fqt_filepath = File::Spec->catdir($cache10k_path, $dp->file_name(ext => 'fastq', suffix => 't'));
   my $fqc1_filepath = File::Spec->catdir($dp_archive_path, $dp->file_name(ext => 'fastqcheck', suffix => '1'));
   my $fqc2_filepath = File::Spec->catdir($dp_archive_path, $dp->file_name(ext => 'fastqcheck', suffix => '2'));
 


### PR DESCRIPTION
I wonder if this code would be simpler if the parent check object used the moniker role to create file names. Then we would only had to supply qc_in.