### PR TITLE
double quote log name to alow for shell special characters

### DIFF
--- a/lib/npg_pipeline/executor/wr.pm
+++ b/lib/npg_pipeline/executor/wr.pm
@@ -156,7 +156,7 @@ sub _definition4job {
     return join q[/], $log_dir, $log_name;
   };
 
-  $def->{'cmd'} = join q[ ], q[(], $d->command(), q[)], q[2>&1], q[|], q[tee], $log_file->();
+  $def->{'cmd'} = join q[ ], q[(], $d->command(), q[)], q[2>&1], q[|], q[tee], q["]. $log_file->() . q["];
 
   return $def;
 }


### PR DESCRIPTION
This should fix the immediate problem (see https://github.com/wtsi-npg/npg_seq_pipeline/issues/332). This branch is based on wtsi/devel, locally three tests failed
t/00-critic.t 
t/20-function-p4_stage1_analysis.t
t/20-function-seq_alignment.t 

They are failing in Travis CI as well