### PR TITLE
minor changes for bcfstats check

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,7 @@ LIST OF CHANGES
    removed; npg_pipeline::function::p4_stage1_analysis module, the only user
    of this function, switched to use the relevant accessor from the
    npg_pipeline::runfolder_scaffold role
+ - minor changes for bcfstats qc check
 
 release 52.1
  - bug fix in jobs names where jobs name should include the pipeline

--- a/data/config_files/function_list_central.json
+++ b/data/config_files/function_list_central.json
@@ -139,6 +139,12 @@
          {
             "relation" : "dependsOn",
             "source" : "seq_alignment",
+            "target" : "qc_bcfstats"
+         },
+
+         {
+            "relation" : "dependsOn",
+            "source" : "seq_alignment",
             "target" : "qc_pulldown_metrics"
          },
          {
@@ -199,6 +205,11 @@
          {
             "relation" : "dependsOn",
             "source" : "bam_cluster_counter_check",
+            "target" : "run_analysis_complete"
+         },
+         {
+            "relation" : "dependsOn",
+            "source" : "qc_bcfstats",
             "target" : "run_analysis_complete"
          },
          {
@@ -329,6 +340,10 @@
          {
             "id" : "seqchksum_comparator",
             "label" : "seqchksum_comparator"
+         },
+         {
+            "id" : "qc_bcfstats",
+            "label" : "qc_bcfstats"
          },
          {
             "id" : "qc_pulldown_metrics",

--- a/lib/npg_pipeline/function/autoqc.pm
+++ b/lib/npg_pipeline/function/autoqc.pm
@@ -78,6 +78,7 @@ sub _build__is_check4target_file {
   my $self = shift;
   ##no critic (RegularExpressions::RequireBracesForMultiline)
   return $self->qc_to_run() =~ /^ adapter |
+                                  bcfstats |
                                   verify_bam_id |
                                   genotype |
                                   pulldown_metrics $/smx;
@@ -219,7 +220,7 @@ sub _generate_command {
   elsif(any { /$check/ } qw( insert_size ref_match sequence_error )) {
     $c .= qq[ --input_files=$fq1_filepath --input_files=$fq2_filepath];
   }
-  elsif(any { /$check/ } qw( adapter genotype verify_bam_id )) {
+  elsif(any { /$check/ } qw( adapter bcfstats genotype verify_bam_id )) {
     $c .= qq{ --input_files=$bamfile_path}; # note: single bam file 
   }
   elsif($check eq q/upstream_tags/) {

--- a/lib/npg_pipeline/pluggable/registry.pm
+++ b/lib/npg_pipeline/pluggable/registry.pm
@@ -66,6 +66,7 @@ Readonly::Array my @SAVE2FILE_STATUS_FUNCTIONS =>
 Readonly::Array my @AUTOQC_FUNCTIONS =>
   qw/
       qc_adapter
+      qc_bcfstats
       qc_gc_fraction
       qc_genotype
       qc_insert_size


### PR DESCRIPTION
Test failures seem to be unrelated to the changes in this pr. The following output in function definitions if teh check should not be run:
  "qc_bcfstats" : [
      {
         "__CLASS__" : "npg_pipeline::function::definition",
         "created_by" : "npg_pipeline::function::autoqc",
         "created_on" : "20180802-144634",
         "excluded" : "1",
         "identifier" : "26422"
      }
   ],
