### PR TITLE
Pass qc_in to upstream tags QC

### DIFF
--- a/lib/npg_pipeline/function/autoqc.pm
+++ b/lib/npg_pipeline/function/autoqc.pm
@@ -223,7 +223,8 @@ sub _generate_command {
     $c .= qq{ --input_files=$bamfile_path}; # note: single bam file 
   }
   elsif($check eq q/upstream_tags/) {
-    $c .= qq{ --tag0_bam_file=$tagzerobamfile_path}; # note: single bam file 
+    $c .= qq{ --tag0_bam_file=$tagzerobamfile_path}; # note: single bam file
+    $c .= qq{ --qc_in=$qc_out_path}; #to find tag metrics
     $c .= qq{ --cal_path=$recal_path};
   }
   else {


### PR DESCRIPTION
so that it can find tag metrics QC for the lane from this analysis rather than looking up qc from disk for the run.