### PR TITLE
set aln_filter_value parameter

### DIFF
--- a/lib/npg_pipeline/function/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/function/p4_stage1_analysis.pm
@@ -273,6 +273,7 @@ sub _generate_command_params { ## no critic (Subroutines::ProhibitExcessComplexi
                     reference_phix => $self->phix_alignment_reference,
                     scramble_reference_fasta => $self->_default_phix_ref(q{fasta}, $self->repository),
                     s1_se_pe => ($self->is_paired_read)? q{pe} : q{se},
+                    aln_filter_value => q{0x900},
                   );
   my %p4_ops = ( splice => [], prune => [], );
 


### PR DESCRIPTION
set p4 aln_filter_value parameter to 0x900 to filter supplementary and secondary alignments from minimap2 output in stage1 analysis