### PR TITLE
fixes to cluster_count and seqchksum_comparator checks

### DIFF
--- a/lib/npg_pipeline/function/cluster_count.pm
+++ b/lib/npg_pipeline/function/cluster_count.pm
@@ -69,6 +69,8 @@ sub create {
 
   my $command = $CLUSTER_COUNT_SCRIPT;
   $command .= q{ --id_run=}            . $id_run;
+  $command .= q[ ];
+  $command .= join q[ ], (map { qq{--lanes=$_} } ($self->positions));
   $command .= q{ --bam_basecall_path=} . $self->bam_basecall_path();
   $command .= q{ --runfolder_path=}    . $self->runfolder_path();
 
@@ -84,7 +86,6 @@ sub create {
     $command .= sprintf qq{ --sf_paths=$sf_path};
   }
 
-  # TODO: deal with dummy position argument in composition creation
   return [
       npg_pipeline::function::definition->new(
       created_by   => __PACKAGE__,
@@ -92,7 +93,6 @@ sub create {
       identifier   => $id_run,
       job_name     => $job_name,
       command      => $command,
-      composition  => $self->create_composition({id_run => $self->id_run, position => 1,})
     )
   ];
 }

--- a/lib/npg_pipeline/function/seqchksum_comparator.pm
+++ b/lib/npg_pipeline/function/seqchksum_comparator.pm
@@ -46,6 +46,8 @@ sub create {
   my $job_name = join q{_}, 'seqchksum_comparator', $self->id_run(), $self->timestamp();
   my $command = $SEQCHKSUM_SCRIPT;
   $command .= q{ --id_run=} . $self->id_run();
+  $command .= q[ ];
+  $command .= join q[ ], (map { qq{--lanes=$_} } ($self->positions));
   $command .= q{ --archive_path=} . $self->archive_path();
   $command .= q{ --bam_basecall_path=} . $self->bam_basecall_path();
   if ($self->verbose() ) {
@@ -62,9 +64,6 @@ sub create {
     created_by   => __PACKAGE__,
     created_on   => $self->timestamp(),
     identifier   => $self->id_run(),
-    composition  =>
-      $self->create_composition({id_run => $self->id_run, position => 1}),
-#     $self->create_composition({rpt_list => qq($self->id_run_1)}),
     job_name     => $job_name,
     command      => $command,
   );

--- a/t/20-function-cluster_count.t
+++ b/t/20-function-cluster_count.t
@@ -67,10 +67,7 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
   
   map {$values->{$_->queue} += 1} @{$da};
   is ($values->{'default'}, 1, 'the queue is set to default for the definition');
-  
-  TODO: { local $TODO = 'currently returning one position - review';
-  }
-
+ 
   my $command = sprintf q[npg_pipeline_check_cluster_count --id_run=1234 --lanes=1 --lanes=2 --lanes=3 --lanes=4 --lanes=5 --lanes=6 --lanes=7 --lanes=8 --bam_basecall_path=%s --runfolder_path=%s %s %s], $bam_basecall_path, $analysis_runfolder_path, join(q{ }, (map {qq[--bfs_paths=$archive_path/lane$_/qc]} (1..8))), join(q{ }, (map {qq[--sf_paths=$archive_path/lane$_/qc]} (1..8)));
 
   is ($da->[0]->command, $command, 'correct command');

--- a/t/20-function-cluster_count.t
+++ b/t/20-function-cluster_count.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use English qw{-no_match_vars};
-use Test::More tests => 36;
+use Test::More tests => 31;
 use Test::Exception;
 use Log::Log4perl qw(:levels);
 use File::Copy qw(cp);
@@ -53,13 +53,7 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
   ok (!$d->excluded, 'step not excluded');
   ok (!$d->has_num_cpus, 'number of cpus is not set');
   ok (!$d->has_memory,'memory is not set');
-  ok ($d->has_composition, 'composition is set');
-  is ($d->composition->num_components, 1, 'one component in a composition');
-  is ($d->composition->get_component(0)->position, 1, 'correct position');
-  ok (!defined $d->composition->get_component(0)->tag_index,
-    'tag index is not defined');
-  ok (!defined $d->composition->get_component(0)->subset,
-    'subset is not defined');
+  ok (!$d->has_composition, 'composition is not set');
   lives_ok {$d->freeze()} 'definition can be serialized to JSON';
 
   my $values = {};
@@ -75,11 +69,9 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
   is ($values->{'default'}, 1, 'the queue is set to default for the definition');
   
   TODO: { local $TODO = 'currently returning one position - review';
-  is (join(q[ ], map {$_->composition->get_component(0)->position} @{$da}),
-    '1 2 3 4 5 6 7 8', 'positions');
   }
 
-  my $command = sprintf q[npg_pipeline_check_cluster_count --id_run=1234 --bam_basecall_path=%s --runfolder_path=%s %s %s], $bam_basecall_path, $analysis_runfolder_path, join(q{ }, (map {qq[--bfs_paths=$archive_path/lane$_/qc]} (1..8))), join(q{ }, (map {qq[--sf_paths=$archive_path/lane$_/qc]} (1..8)));
+  my $command = sprintf q[npg_pipeline_check_cluster_count --id_run=1234 --lanes=1 --lanes=2 --lanes=3 --lanes=4 --lanes=5 --lanes=6 --lanes=7 --lanes=8 --bam_basecall_path=%s --runfolder_path=%s %s %s], $bam_basecall_path, $analysis_runfolder_path, join(q{ }, (map {qq[--bfs_paths=$archive_path/lane$_/qc]} (1..8))), join(q{ }, (map {qq[--sf_paths=$archive_path/lane$_/qc]} (1..8)));
 
   is ($da->[0]->command, $command, 'correct command');
 }

--- a/t/20-function-seqchksum_comparator.t
+++ b/t/20-function-seqchksum_comparator.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 23;
+use Test::More tests => 19;
 use Test::Exception;
 use Log::Log4perl qw(:levels);
 use t::util;
@@ -45,7 +45,6 @@ my $archive_path = $recalibrated_path . q{/archive};
 
   isa_ok( $object, q{npg_pipeline::function::seqchksum_comparator});
   my $da = $object->create();
-# ok ($da && @{$da} == 2, 'an array with two definitions is returned');
   ok ($da && @{$da} == 1, 'an array with one definition is returned');
   my $d = $da->[0];
   isa_ok($d, q{npg_pipeline::function::definition});
@@ -53,19 +52,12 @@ my $archive_path = $recalibrated_path . q{/archive};
     'created_by is correct');
   is ($d->created_on, $object->timestamp, 'created_on is correct');
   is ($d->identifier, 1234, 'identifier is set correctly');
-  ok ($d->has_composition, 'composition is set');
-  is ($d->composition->num_components, 1, 'one componet in a composition');
-  is ($d->composition->get_component(0)->position, 1, 'correct position');
-  ok (!defined $d->composition->get_component(0)->tag_index,
-    'tag index is not defined');
-  ok (!defined $d->composition->get_component(0)->subset,
-    'subset is not defined');
+  ok (!$d->has_composition, 'no composition is not set');
   is ($d->job_name, q{seqchksum_comparator_1234_20100907-142417},
     'job_name is correct');
   is ($d->command,
-    q{npg_pipeline_seqchksum_comparator --id_run=1234 --archive_path=} .
-#   qq{$archive_path --bam_basecall_path=$bam_basecall_path --lanes=1},
-    qq{$archive_path --bam_basecall_path=$bam_basecall_path} .
+    q{npg_pipeline_seqchksum_comparator --id_run=1234 --lanes=1 --lanes=2} .
+    qq{ --archive_path=$archive_path --bam_basecall_path=$bam_basecall_path} .
     qq{ --input_globs=$archive_path/lane1/1234_1*.cram} .
     qq{ --input_globs=$archive_path/lane2/1234_2*.cram},
     'command is correct');
@@ -75,15 +67,6 @@ my $archive_path = $recalibrated_path . q{/archive};
   is ($d->queue, 'default', 'default queue');
   lives_ok {$d->freeze()} 'definition can be serialized to JSON';
 
-# seqchksum_comparator is now done at run-level, so only one definition
-# $d = $da->[1];
-# is ($d->composition->get_component(0)->position, 2, 'position');
-# is ($d->command,
-#   q{npg_pipeline_seqchksum_comparator --id_run=1234 --archive_path=} .
-#   qq{$archive_path --bam_basecall_path=$bam_basecall_path --lanes=2},
-#   'command is correct');
-
-# throws_ok{$object->do_comparison()} qr/Cannot find/,
   throws_ok{$object->do_comparison()} qr/Failed to change directory/,
     q{Doing a comparison with no files throws an exception}; 
 
@@ -156,13 +139,7 @@ my $archive_path = $recalibrated_path . q{/archive};
   );
   $da = $object->create();
   # seqchksum_comparator is now a run-level function, so only one definition returned
-# ok ($da && @{$da} == 8, 'an array with eight definitions is returned');
   ok ($da && @{$da} == 1, 'an array with one definition is returned for eight lanes');
-
-# now that this function is run-level only, lanes attribute is not needed
-# throws_ok{ $object->do_comparison() }
-#   qr/Lanes have to be given explicitly/,
-#   q{lanes attribute is needed to run the comparison};
 }
 
 1;


### PR DESCRIPTION
Now that they are run-level checks and an analysis may use a subset of lanes,
explicitly specify lanes when creating the script commands for cluster_count
and seqchksum checks.

Remove the unneeded composition attribute when creating the command
definition (no more dummy lane position keys in the command file).

Update tests.