### PR TITLE
change components_as_products method of npg_pipeline::product to

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 LIST OF CHANGES
 ---------------
 
- - a wrapper object npg_pipeline::product to repesent a product
+ - a wrapper object npg_pipeline::product to represent a product
  - upfront definition of all products
  - generic runfolder scaffolding for any products
  - since the top-level qc directory is no longer required, the tileviz
@@ -36,6 +36,9 @@ LIST OF CHANGES
  - change signature of the autoqc archival job in line with extended
    functionality of the autoqc db loader (ability to find JSON files
    in the run folder)
+ - change components_as_products method of npg_pipeline::product to
+   return a list with one item when there is only one component in
+   the composition (instead of an empty list)
 
 release 52.1
  - bug fix in jobs names where jobs name should include the pipeline

--- a/lib/npg_pipeline/product.pm
+++ b/lib/npg_pipeline/product.pm
@@ -358,7 +358,7 @@ sub is_tag_zero_product {
 
 =head2 components_as_products
 
-For a product with multiple components, returns a list of
+For a product with any number of components, returns a list of
 objects of this class representing individual components.
 
 The subset information is not retained in the returned objects.
@@ -377,11 +377,9 @@ The lims attribute of the returned objects is not set.
 sub components_as_products {
   my $self = shift;
   my @components = ();
-  if ($self->composition->num_components() > 1) {
-    foreach my $c ($self->composition->components_list()) {
-      push  @components, __PACKAGE__->new(selected_lanes => $self->selected_lanes,
-                                          rpt_list       => $c->freeze2rpt());
-    }
+  foreach my $c ($self->composition->components_list()) {
+    push  @components, __PACKAGE__->new(selected_lanes => $self->selected_lanes,
+                                        rpt_list       => $c->freeze2rpt());
   }
   return @components;
 }

--- a/t/10-product.t
+++ b/t/10-product.t
@@ -233,10 +233,11 @@ subtest 'generation of product objects for components' => sub {
   plan tests => 17;
 
   my $p = npg_pipeline::product->new(rpt_list => '26219:1:3');
-  is ($p->components_as_products(), 0, 'empty list for a single component');
+  my @p_components = $p->components_as_products();
+  is (scalar @p_components, 1, 'one-item list for a single component');
 
   $p = npg_pipeline::product->new(rpt_list => '26219:1:3;26219:2:3;26219:3:3;26219:4:3');
-  my @p_components = $p->components_as_products();
+  @p_components = $p->components_as_products();
   is (scalar @p_components, 4, 'four products');
   map { isa_ok ($_, 'npg_pipeline::product') }  @p_components;
   ok ((all { ! $_->selected_lanes } @p_components),


### PR DESCRIPTION
 return a list with one item when there is only one component in
 the composition (instead of an empty list)