### PR TITLE
S2merge revisit

### DIFF
--- a/lib/npg_pipeline/function/autoqc.pm
+++ b/lib/npg_pipeline/function/autoqc.pm
@@ -230,10 +230,16 @@ sub _generate_command {
   ##no critic (RegularExpressions::RequireExtendedFormatting)
   ##no critic (ControlStructures::ProhibitCascadingIfElse)
   if(any { /$check/sm } qw( gc_fraction qX_yield )) {
-    $c .= qq[ --input_files=$fqc1_filepath --input_files=$fqc2_filepath];
+    $c .= qq[ --input_files=$fqc1_filepath];
+    if($self->is_paired_read) {
+      $c .= qq[ --input_files=$fqc2_filepath];
+    }
   }
   elsif(any { /$check/sm } qw( insert_size ref_match sequence_error )) {
-    $c .= qq[ --input_files=$fq1_filepath --input_files=$fq2_filepath];
+    $c .= qq[ --input_files=$fq1_filepath];
+    if($self->is_paired_read) {
+      $c .= qq[ --input_files=$fq2_filepath];
+    }
   }
 
   elsif(any { /$check/sm } qw( adapter bcfstats genotype verify_bam_id pulldown_metrics )) {

--- a/lib/npg_pipeline/function/autoqc.pm
+++ b/lib/npg_pipeline/function/autoqc.pm
@@ -254,13 +254,14 @@ sub _generate_command {
 
     my $position = $dp->composition->get_component(0)->position; # lane-level check, so position is unique
 
+    my %qc_in_roots = ();
     for my $redp (@{$self->products->{data_products}}) {
       # find any merged products with components from this position (lane)
       if(any { $_->{position} == $position } @{$redp->composition->{components}}) {
-        my $input_file = File::Spec->catdir($redp->path($self->archive_path), $redp->file_name(ext => 'spatial_filter.stats'));
-        $c .= qq{ --input_files=$input_file};
+        $qc_in_roots{$self->archive_path} = 1;
       }
     }
+    $c .= q[ ] . join q[ ], (map {"--qc_in=$_"} (keys %qc_in_roots));
   }
   else {
     ## default input_files [none?]

--- a/lib/npg_pipeline/function/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/function/p4_stage1_analysis.pm
@@ -412,21 +412,17 @@ sub _generate_command_params {
       $p4_params{bid_max_no_calls} = $self->general_values_conf()->{single_plex_decode_max_no_calls};
       $p4_params{bid_convert_low_quality_to_no_call_flag} = q[--convert-low-quality];
     }
-    if(not $self->adapterfind) {
-      push @{$p4_ops{splice}}, q[bamadapterfind];
-    }
-    push @{$p4_ops{prune}}, q[tee_split:unsplit_bam-];
+    push @{$p4_ops{prune}}, q[tee_split:unsplit_bam-]; # no lane-level bam/cram when plexed
   }
   else {
     $self->info(q{P4 stage1 analysis on non-plexed lane});
 
-    if(not $self->adapterfind) {
-      push @{$p4_ops{splice}}, q[tee_i2b:baf-bamcollate:];
-    }
-    else {
-      push @{$p4_ops{splice}}, q[bamadapterfind:-bamcollate:];
-    }
-    push @{$p4_ops{prune}}, q[tee_split:split_bam-];
+    push @{$p4_ops{splice}}, q[tee_i2b:baf-bamcollate:]; # skip decode when unplexed
+    push @{$p4_ops{prune}}, q[tee_split:split_bam-]; # no split output when unplexed
+  }
+
+  if(not $self->adapterfind) {
+    push @{$p4_ops{splice}}, q[bamadapterfind];
   }
 
   # cluster count (used to calculate FRAC for bam subsampling)

--- a/lib/npg_pipeline/function/p4_stage1_analysis.pm
+++ b/lib/npg_pipeline/function/p4_stage1_analysis.pm
@@ -57,11 +57,10 @@ sub generate {
 
     my $p = $lane_product->composition->{components}->[0]->{position}; # there should be only one element in components
 
-    my $l = $alims->{$p};
-#   my $l = $lane_product->lims;
+    my $l = $lane_product->lims;
     my $tag_list_file = q{};
 
-    if ($l->tags) { # adequate proxy for is_multiplexed?
+    if($l->is_pool) {
       $self->info(qq{Lane $p is indexed, generating tag list});
 
       $tag_list_file = npg_pipeline::cache::barcodes->new(

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -152,6 +152,11 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   my $spike_tag = $dp->lims->is_phix_spike;
   my $reference_genome = $dp->lims->reference_genome || q[UNSPEC];
   my $is_tag_zero_product = $dp->is_tag_zero_product;
+  my $run_vec = [ uniq (map { $_->{id_run} } @{$dp->composition->{components}}) ];
+  my $id_run = $run_vec->[0]; # assume unique for the moment
+  my $tags_vec = [ uniq (map { $_->{tag_index} } @{$dp->composition->{components}}) ];
+  my $tag_index = $tags_vec->[0]; # assume unique for the moment
+  my $is_plex = defined $tag_index;
 
   my $archive_path = $self->archive_path;
   my $dp_archive_path = $dp->path($archive_path);
@@ -203,9 +208,6 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   $self->debug(qq{  bfs_input_file: $bfs_input_file});
   $self->debug(qq{  af_input_file: $af_input_file});
 
-  my $id_run = (defined $dp->lims->id_run? $dp->lims->id_run: q[UNDEF]);
-  my $tag_index = (defined $dp->lims->tag_index? $dp->lims->tag_index: q[UNDEF]);
-  my $is_plex = defined $dp->lims->tag_index; # would this work if there were multiple tag indexes in the product?
   my $l = $dp->lims;
 
   ################################################

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -296,6 +296,16 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
 
   my $skip_target_markdup_metrics = (not $spike_tag and not $do_target_alignment);
 
+  if($human_split and not $do_target_alignment and not $spike_tag) {
+    # human_split needs alignment. The final_output_prep_no_y_target parameter specifies a p4 template
+    #  which will undo the alignment from the target product after the split has been done.
+
+    $do_target_alignment = 1;
+    $skip_target_markdup_metrics = 1;
+
+    $p4_param_vals->{final_output_prep_no_y_target} = q[final_output_prep_chrsplit_noaln.json];
+  }
+
   # handle extra stats file for aligned data with reference regions file
   my $do_target_regions_stats = 0;
   if ($do_target_alignment && !$spike_tag && !$human_split && !$do_gbs_plex && !$do_rna) {
@@ -316,13 +326,6 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   }
   elsif( !($human_split and not $do_target_alignment) ){
    push @{$p4_ops->{prune}}, 'fop.*samtools_stats_F0.*_target.*-';
-  }
-
-  if($human_split and not $do_target_alignment and not $spike_tag) {
-    $do_target_alignment = 1;
-    $skip_target_markdup_metrics = 1;
-
-    $p4_param_vals->{final_output_prep_no_y_target} = q[final_output_prep_chrsplit_noaln.json];
   }
 
   my $nchs = $do_gbs_plex ? q{} : $l->contains_nonconsented_human;

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -266,7 +266,8 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
     push @{$p4_ops->{prune}}, 'fopt.*_bmd_multiway:calibration_pu-';
   }
 
-  if(not $is_plex) {
+# if(not $is_plex) {
+  if(not $is_pool) {
     push @{$p4_ops->{prune}}, 'ssfqc_tee_ssfqc:subsample-';
     push @{$p4_ops->{prune}}, 'ssfqc_tee_ssfqc:fqc-';
   }
@@ -533,34 +534,36 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
     q{&&},
     qq(viv.pl -s -x -v 3 -o viv_$name_root.log run_$name_root.json ),
     q{&&},
-    _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $l, $is_plex, undef,
+    _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $is_pool, undef,
                 $skip_target_markdup_metrics, $rpt_list, $name_root, [$bfs_input_file]),
     (grep {$_}
       ($spike_tag ? q() : (join q( ),
         q{&&},
-        _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $l, $is_plex, 'phix', undef, $rpt_list, $name_root, [$bfs_input_file]),
+        _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $is_pool, 'phix', undef, $rpt_list, $name_root, [$bfs_input_file]),
         q{&&},
-        _qc_command_alt('alignment_filter_metrics', undef, $qc_out_path, $l, $is_plex, undef, undef, $rpt_list, $name_root, [$af_input_file]),
+        _qc_command_alt('alignment_filter_metrics', undef, $qc_out_path, $is_pool, undef, undef, $rpt_list, $name_root, [$af_input_file]),
       ),
 
       $human_split ? (join q( ),
         q{&&},
-        _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $l, $is_plex, $human_split, undef, $rpt_list, $name_root, [$bfs_input_file]),
+        _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $is_pool, $human_split, undef, $rpt_list, $name_root, [$bfs_input_file]),
       ) : q()),
 
       $nchs ? (join q( ),
         q{&&},
-        _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $l, $is_plex, $nchs_outfile_label, undef, $rpt_list, $name_root, [$bfs_input_file]),
+        _qc_command_alt('bam_flagstats', $dp_archive_path, $qc_out_path, $is_pool, $nchs_outfile_label, undef, $rpt_list, $name_root, [$bfs_input_file]),
       ) : q(),
 
       $do_rna ? (join q( ),
         q{&&},
-        _qc_command('rna_seqc', $dp_archive_path, $qc_out_path, $l, $is_plex),
+#       _qc_command('rna_seqc', $dp_archive_path, $qc_out_path, $l, $is_pool),
+        _qc_command_alt('rna_seqc', $dp_archive_path, $qc_out_path, $is_pool, undef, undef, $rpt_list, $name_root),
       ) : q(),
 
       $do_gbs_plex ? (join q( ),
         q{&&},
-        _qc_command('genotype_call', $dp_archive_path, $qc_out_path, $l, $is_plex),
+#       _qc_command('genotype_call', $dp_archive_path, $qc_out_path, $l, $is_pool),
+        _qc_command_alt('genotype_call', $dp_archive_path, $qc_out_path, $is_pool, undef, undef, $rpt_list, $name_root),
       ) : q()
     ),
 
@@ -568,7 +571,7 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
 }
 
 sub _qc_command_alt {##no critic (Subroutines::ProhibitManyArgs)
-  my ($check_name, $qc_in, $qc_out, $l, $is_plex, $subset, $skip_markdups_metrics, $rpt_list, $filename_root, $input_files) = @_;
+  my ($check_name, $qc_in, $qc_out, $is_pool, $subset, $skip_markdups_metrics, $rpt_list, $filename_root, $input_files) = @_;
 
   my $args = {
                'rpt_list' => q["] . $rpt_list . q["],

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -112,18 +112,13 @@ sub generate {
   my $ref = {};
   for my $dp (@{$self->products->{data_products}}) {
 
-#   my $phix_subset_file = $dp->file_name(ext => 'cram', suffix => 'phix');
-#   $ref->{'composition_subsets'} = { composition => $dp->composition->freeze, subsets => [ $phix_subset_file, ], };
-    my $css = { composition => $dp->composition->freeze, subsets => [ $dp->file_name(ext => 'cram', suffix => 'phix'), ], };
-
+    my $subsets_composition = { composition => from_json($dp->composition->freeze), subsets => [ $dp->file_name(ext => 'cram', suffix => 'phix'), ], };
     $ref->{'memory'} = $MEMORY; # reset to default
-    $ref->{'command'} = $self->_alignment_command($dp, $ref);
+    $ref->{'command'} = $self->_alignment_command($dp, $ref, $subsets_composition);
     push @definitions, $self->_create_definition($ref, $dp);
 
     my $composition_file = File::Spec->catdir($dp->path($self->archive_path), $dp->file_name(ext => 'json', suffix => 'composition'));
-#   my $contents = $dp->composition->freeze;
-#   write_file($composition_file, $contents);
-    write_file($composition_file, encode_json($css));
+    write_file($composition_file, encode_json($subsets_composition));
   }
 
   return \@definitions;
@@ -147,7 +142,7 @@ sub _create_definition {
 }
 
 sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
-  my ( $self, $dp, $ref) = @_;   # this should be enough?
+  my ( $self, $dp, $ref, $subsets_composition) = @_;
 
   ########################################################
   # derive base parameters from supplied data_product (dp)
@@ -439,8 +434,6 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
     }
   }
   else {
-#   my ($organism, $strain, $tversion, $analysis) = npg_tracking::data::reference->new(rpt_list => $rpt_list)->parse_reference_genome($l->reference_genome);
-#   my ($organism, $strain, $tversion, $analysis) = npg_tracking::data::reference->new(repository => $self->repository)->parse_reference_genome($l->reference_genome);
     my ($organism, $strain, $tversion, $analysis) = npg_tracking::data::reference->new(($self->repository ? (q(repository)=>$self->repository) : ()))->parse_reference_genome($l->reference_genome);
 
     $p4_param_vals->{bwa_executable} = q[bwa0_6];
@@ -482,6 +475,14 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
       $p4_param_vals->{chrsplit_subset_flag} = ['--subset', 'Y,chrY,ChrY,chrY_KI270740v1_random'];
       $p4_param_vals->{chrsplit_invert_flag} = q[--invert];
     }
+  }
+
+  # update subsets for composition file
+  if($human_split) {
+    push @{$subsets_composition->{subsets}}, $dp->file_name(ext => 'cram', suffix => $human_split);
+  }
+  if($nchs) {
+    push @{$subsets_composition->{subsets}}, $dp->file_name(ext => 'cram', suffix => 'human');
   }
 
   # write p4 parameters to file
@@ -627,8 +628,6 @@ sub _do_rna_analysis {
       return 0;
     }
   }
-# my @parsed_ref_genome = npg_tracking::data::reference->new({rpt_list => $rpt_list})->parse_reference_genome($reference_genome);
-# my @parsed_ref_genome = npg_tracking::data::reference->new({rpt_list => $rpt_list})->parse_reference_genome($reference_genome);
   my @parsed_ref_genome = npg_tracking::data::reference->new(($self->repository ? (q(repository)=>$self->repository) : ()))->parse_reference_genome($reference_genome);
   my $transcriptome_version = $parsed_ref_genome[$REFERENCE_ARRAY_TVERSION_IDX] // q[];
   if (not $transcriptome_version) {
@@ -658,7 +657,6 @@ sub _transcriptome {
 sub _analysis {
     my ($self, $reference_genome, $rpt_list) = @_;
     $reference_genome //= q[];
-#   my @parsed_ref_genome = npg_tracking::data::reference->new({ rpt_list => $rpt_list, })->parse_reference_genome($reference_genome);
     my @parsed_ref_genome = npg_tracking::data::reference->new(($self->repository ? (q(repository)=>$self->repository) : ()))->parse_reference_genome($reference_genome);
     my $analysis = $parsed_ref_genome[$REFERENCE_ARRAY_ANALYSIS_IDX];
     $self->info(qq[$rpt_list - Analysis: ] . (defined $analysis ? $analysis : qq[default for $reference_genome]));

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -114,6 +114,10 @@ sub generate {
     $ref->{'memory'} = $MEMORY; # reset to default
     $ref->{'command'} = $self->_alignment_command($dp, $ref);
     push @definitions, $self->_create_definition($ref, $dp);
+
+    my $composition_file = File::Spec->catdir($dp->path($self->archive_path), $dp->file_name(ext => 'json', suffix => 'composition'));
+    my $contents = $dp->composition->freeze;
+    write_file($composition_file, $contents);
   }
 
   return \@definitions;

--- a/t/20-function-autoqc.t
+++ b/t/20-function-autoqc.t
@@ -184,6 +184,7 @@ subtest 'qX_yield' => sub {
     qc_to_run         => q{qX_yield},
     timestamp         => q{20090709-123456},
     is_indexed        => 0,
+    is_paired_read    => 1,
   );
   my $da = $aqc->create();
   ok ($da && (@{$da} == 8), 'eight definitions returned');
@@ -213,6 +214,7 @@ subtest 'qX_yield' => sub {
     lanes             => [4],
     timestamp         => q{20090709-123456},
     is_indexed        => 0,
+    is_paired_read    => 1,
   );
   $da = $aqc->create();
   ok ($da && (@{$da} == 1), 'one definition returned');
@@ -228,6 +230,7 @@ subtest 'qX_yield' => sub {
     qc_to_run         => q{qX_yield},
     timestamp         => q{20090709-123456},
     is_indexed        => 1,
+    is_paired_read    => 1,
   );
   $da = $aqc->create();
   ok ($da && (@{$da} == 1), 'one definition returned - lane is not a pool');
@@ -244,6 +247,7 @@ subtest 'qX_yield' => sub {
     qc_to_run         => q{qX_yield},
     timestamp         => q{20090709-123456},
     is_indexed        => 1,
+    is_paired_read    => 0,
   );
 
   $da = $aqc->create();
@@ -253,9 +257,9 @@ subtest 'qX_yield' => sub {
   foreach my $d (@plexes) {
     my $t = $d->composition->get_component(0)->tag_index;
     is ($d->command, sprintf(
-    'qc --check=qX_yield --rpt_list=%s --filename_root=%s --qc_out=%s --input_files=%s --input_files=%s',
-    qq["1234:8:${t}"], "1234_8#${t}", "$archive_dir/lane8/plex${t}/qc", "$archive_dir/lane8/plex${t}/1234_8#${t}_1.fastqcheck", "$archive_dir/lane8/plex${t}/1234_8#${t}_2.fastqcheck"),
-    "qX_yield command for lane 8 tag $t");
+    'qc --check=qX_yield --rpt_list=%s --filename_root=%s --qc_out=%s --input_files=%s',
+    qq["1234:8:${t}"], "1234_8#${t}", "$archive_dir/lane8/plex${t}/qc", "$archive_dir/lane8/plex${t}/1234_8#${t}_1.fastqcheck"),
+    "qX_yield command for lane 8 tag $t (s/e)");
   }
 
   fcopy('t/data/run_params/runParameters.hiseq.xml', "$rf_path/runParameters.xml")
@@ -275,6 +279,7 @@ subtest 'ref_match' => sub {
     timestamp         => q{20090709-123456},
     repository        => 't/data/sequence',
     is_indexed        => 1,
+    is_paired_read    => 1,
   );
   my $da = $aqc->create();
   ok ($da && (@{$da} == 3), 'three definitions returned - lane is a pool');

--- a/t/20-function-autoqc.t
+++ b/t/20-function-autoqc.t
@@ -138,8 +138,8 @@ subtest 'spatial_filter' => sub {
   foreach my $de (@{$da}) {
     my $p = $de->composition->get_component(0)->position;
     is ($de->command, sprintf(
-    'qc --check=spatial_filter --rpt_list=%s --filename_root=%s --qc_out=%s --input_files=%s',
-    qq["1234:${p}"], "1234_${p}", "$archive_dir/lane${p}/qc", "$archive_dir/lane${p}/1234_${p}.spatial_filter.stats"),
+    'qc --check=spatial_filter --rpt_list=%s --filename_root=%s --qc_out=%s --qc_in=%s',
+    qq["1234:${p}"], "1234_${p}", "$archive_dir/lane${p}/qc", $archive_dir),
     "spatial filter check command for lane $p, lane not indexed");
   }
 
@@ -167,8 +167,8 @@ subtest 'spatial_filter' => sub {
   foreach my $de (@{$da}) {
     my $p = $de->composition->get_component(0)->position;
     my @t = (map { $_->tag_index } ($de->composition->components_list()));
-    is ($de->command, sprintf('qc --check=spatial_filter --rpt_list=%s --filename_root=%s --qc_out=%s %s',
-                                 qq["8747:${p}"], "8747_${p}", "$archive_dir/lane${p}/qc", join q{ }, map { "--input_files=$archive_dir/lane${p}/plex$_/8747_${p}#$_.spatial_filter.stats" } @{$expected_tags{${p}}},  ),
+    is ($de->command, sprintf('qc --check=spatial_filter --rpt_list=%s --filename_root=%s --qc_out=%s --qc_in=%s',
+                                 qq["8747:${p}"], "8747_${p}", "$archive_dir/lane${p}/qc", $archive_dir),
     "spatial filter check command for lane $p, lane is indexed");
   }   
 };

--- a/t/20-function-cluster_count.t
+++ b/t/20-function-cluster_count.t
@@ -25,6 +25,8 @@ my $archive_path = $recalibrated_path . q{/archive};
 
 cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runParameters.xml";
 
+`touch $recalibrated_path/1234_bfs_fofn.txt`;
+`touch $recalibrated_path/1234_sf_fofn.txt`;
 {
   local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_1234.csv];
 
@@ -37,6 +39,8 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
       id_run            => 1234,
       timestamp         => q{20100907-142417},
       is_indexed        => 0,
+      bfs_fofp_name => q{},
+      sf_fofp_name => q{},
     );
   } q{obtain object ok};
 
@@ -69,6 +73,7 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
   is ($values->{'default'}, 1, 'the queue is set to default for the definition');
  
   my $command = sprintf q[npg_pipeline_check_cluster_count --id_run=1234 --lanes=1 --lanes=2 --lanes=3 --lanes=4 --lanes=5 --lanes=6 --lanes=7 --lanes=8 --bam_basecall_path=%s --runfolder_path=%s %s %s], $bam_basecall_path, $analysis_runfolder_path, join(q{ }, (map {qq[--bfs_paths=$archive_path/lane$_/qc]} (1..8))), join(q{ }, (map {qq[--sf_paths=$archive_path/lane$_/qc]} (1..8)));
+# my $command = sprintf q[npg_pipeline_check_cluster_count --id_run=1234 --lanes=1 --lanes=2 --lanes=3 --lanes=4 --lanes=5 --lanes=6 --lanes=7 --lanes=8 --bam_basecall_path=%s --runfolder_path=%s --bfs_fofp_name=%s/1234_bfs_fofn.txt --sf_fofp_name=%s/1234_sf_fofn.txt], $bam_basecall_path, $analysis_runfolder_path, $recalibrated_path, $recalibrated_path;
 
   is ($da->[0]->command, $command, 'correct command');
 }
@@ -88,6 +93,8 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
       bam_basecall_path => $bam_basecall_path,
       archive_path => $archive_path,
       bfs_paths    => [ qq[$archive_path/lane1/qc] ],
+      bfs_fofp_name => q{},
+      sf_fofp_name => q{},
     );
   } q{obtain object ok};
 
@@ -109,6 +116,8 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
       bam_basecall_path => $bam_basecall_path,
       archive_path => $archive_path,
       bfs_paths    => [ qq{$archive_path/lane3/qc} ],
+      bfs_fofp_name => q{},
+      sf_fofp_name => q{},
     );
   } q{obtain object ok};
   
@@ -147,6 +156,8 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
       archive_path => $archive_path,
       bfs_paths    => [ qq{$archive_path/lane1/qc} ],
       sf_paths     => [ qq{$archive_path/lane1/qc} ],
+      bfs_fofp_name => q{},
+      sf_fofp_name => q{},
     );
   } q{obtain object ok};
 
@@ -163,11 +174,12 @@ cp 't/data/run_params/runParameters.miseq.xml',  "$analysis_runfolder_path/runPa
   my $analysis_runfolder_path = 't/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX';
   my $bam_basecall_path = "$analysis_runfolder_path/Data/Intensities/BAM_basecalls_20130122-085552";
   my $archive_path = "$bam_basecall_path/PB_cal_bam/archive";
+  my $recalibrated_path = "$bam_basecall_path/PB_cal_bam";
   my $qc_path = "$archive_path/qc";
 
   my $common_command = sub {
     my $p = shift;
-    return sprintf q{$EXECUTABLE_NAME bin/npg_pipeline_check_cluster_count --id_run 8747 --bam_basecall_path %s --qc_path %s --lanes %d --bfs_paths=%s/lane%d/qc --sf_paths=%s/lane%d/qc}, $bam_basecall_path, $qc_path, $p, $archive_path, $p, $archive_path, $p;
+    return sprintf q{$EXECUTABLE_NAME bin/npg_pipeline_check_cluster_count --bfs_fofp_name %s/lane%d/8747_bfs_fofn.txt --sf_fofp_name %s/lane%d/8747_sf_fofn.txt --id_run 8747 --bam_basecall_path %s --qc_path %s --lanes %d}, $archive_path, $p, $archive_path, $p, $bam_basecall_path, $qc_path, $p;
   };
 
   my $c;

--- a/t/20-function-p4_stage1_analysis.t
+++ b/t/20-function-p4_stage1_analysis.t
@@ -171,7 +171,7 @@ subtest 'check_save_arguments' => sub {
         },
     ],
     'ops' => {
-      'splice' => [ 'bamadapterfind:-bamcollate:' ],
+      'splice' => [ 'tee_i2b:baf-bamcollate:' ],
       'prune' => [ 'tee_split:split_bam-'
       ]
     },
@@ -290,7 +290,7 @@ subtest 'check_save_arguments_minimap2' => sub {
         },
     ],
     'ops' => {
-      'splice' => [ 'bamadapterfind:-bamcollate:' ],
+      'splice' => [ 'tee_i2b:baf-bamcollate:' ],
       'prune' => [ 'tee_split:split_bam-'
       ]
     },

--- a/t/20-function-seq_alignment.t
+++ b/t/20-function-seq_alignment.t
@@ -175,7 +175,6 @@ subtest 'test 1' => sub {
       verbose           => 0,
       repository        => $dir,
       force_phix_split  => 0,
-      roles => qw/npg_pipeline::runfolder_scaffold/,
     )
   } 'no error creating an object';
 

--- a/t/20-function-seq_alignment.t
+++ b/t/20-function-seq_alignment.t
@@ -14,6 +14,7 @@ use JSON;
 use Cwd;
 use List::Util qw/first/;
 
+use Moose::Util qw(apply_all_roles);
 
 use st::api::lims;
 
@@ -174,6 +175,7 @@ subtest 'test 1' => sub {
       verbose           => 0,
       repository        => $dir,
       force_phix_split  => 0,
+      roles => qw/npg_pipeline::runfolder_scaffold/,
     )
   } 'no error creating an object';
 
@@ -181,6 +183,9 @@ subtest 'test 1' => sub {
 
   my $qc_in  = $dir . q[/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/lane4/plex3];
   my $qc_out = join q[/], $qc_in, q[qc];
+
+  apply_all_roles($rna_gen, 'npg_pipeline::runfolder_scaffold');
+  $rna_gen->create_product_level();
 
   my $da = $rna_gen->generate();
   ok ($da && @{$da} == 8, 'array of 8 definitions is returned');
@@ -192,7 +197,7 @@ subtest 'test 1' => sub {
     qq{ && qc --check bam_flagstats --filename_root 12597_4#3 --qc_in $qc_in --qc_out $qc_out --rpt_list "12597:4:3" --input_files $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/lane4/plex3/12597_4#3.bam} .
     qq{ && qc --check bam_flagstats --filename_root 12597_4#3_phix --qc_in $qc_in --qc_out $qc_out --rpt_list "12597:4:3" --subset phix --input_files $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/lane4/plex3/12597_4#3.bam} .
      q{ && qc --check alignment_filter_metrics --filename_root 12597_4#3 --qc_in $PWD --qc_out }.$qc_out.q{ --rpt_list "12597:4:3" --input_files 12597_4#3_bam_alignment_filter_metrics.json} .
-    qq{ && qc --check rna_seqc --filename_root 12597_4#3 --qc_in $qc_in --qc_out } . $qc_out . q{ --rpt_list "12597:4:3"}.
+    qq{ && qc --check rna_seqc --filename_root 12597_4#3 --qc_in $qc_in --qc_out } . $qc_out . qq{ --rpt_list "12597:4:3" --input_files $dir/140409_HS34_12597_A_C333TACXX/Data/Intensities/BAM_basecalls_20140515-073611/no_cal/archive/lane4/plex3/12597_4#3.bam}.
      q{ '};
 
   my $mem = 32000;
@@ -309,6 +314,9 @@ subtest 'test 2' => sub {
   } 'no error creating an object';
   is ($rna_gen->id_run, 13066, 'id_run inferred correctly');
 
+  apply_all_roles($rna_gen, 'npg_pipeline::runfolder_scaffold');
+  $rna_gen->create_product_level();
+
   my $da = $rna_gen->generate();
   ok ($da && @{$da} == 2, 'array of two definitions is returned');
   my $d = _find($da, 8);
@@ -320,7 +328,7 @@ subtest 'test 2' => sub {
     qq{ && qc --check bam_flagstats --filename_root 13066_8 --qc_in $qc_in --qc_out $qc_out --rpt_list "13066:8" --input_files $dir/140529_HS18_13066_A_C3C3KACXX/Data/Intensities/BAM_basecalls_20140606-133530/no_cal/archive/lane8/13066_8.bam} .
     qq{ && qc --check bam_flagstats --filename_root 13066_8_phix --qc_in $qc_in --qc_out $qc_out --rpt_list "13066:8" --subset phix --input_files $dir/140529_HS18_13066_A_C3C3KACXX/Data/Intensities/BAM_basecalls_20140606-133530/no_cal/archive/lane8/13066_8.bam} .
      q{ && qc --check alignment_filter_metrics --filename_root 13066_8 --qc_in $PWD --qc_out } . $qc_out . qq{ --rpt_list "13066:8" --input_files 13066_8_bam_alignment_filter_metrics.json} .
-    qq{ && qc --check rna_seqc --filename_root 13066_8 --qc_in $qc_in --qc_out } . $qc_out . q{ --rpt_list "13066:8" '};
+    qq{ && qc --check rna_seqc --filename_root 13066_8 --qc_in $qc_in --qc_out } . $qc_out . qq{ --rpt_list "13066:8" --input_files $dir/140529_HS18_13066_A_C3C3KACXX/Data/Intensities/BAM_basecalls_20140606-133530/no_cal/archive/lane8/13066_8.bam '};
 
   is ($d->command, $command, 'correct command for lane 8');
   is ($d->memory, 32000, 'memory');
@@ -361,6 +369,9 @@ subtest 'test 2' => sub {
     )
   } 'no error creating an object';
   is ($rna_gen->id_run, 17550, 'id_run inferred correctly');
+
+  apply_all_roles($rna_gen, 'npg_pipeline::runfolder_scaffold');
+  $rna_gen->create_product_level();
 
   $da = $rna_gen->generate();
   $d = _find($da, 3, 1);
@@ -463,6 +474,9 @@ subtest 'test 3' => sub {
      q{ && qc --check alignment_filter_metrics --filename_root 18472_2#1 --qc_in $PWD --qc_out } .$qc_out.q{ --rpt_list "18472:2:1" --input_files 18472_2#1_bam_alignment_filter_metrics.json}.
      q{ '};
 
+  apply_all_roles($se_gen, 'npg_pipeline::runfolder_scaffold');
+  $se_gen->create_product_level();
+
   my $da = $se_gen->generate();
   my $d = _find($da, 2, 1);
   is ($d->command, $command, 'correct command for lane 2 plex 1');
@@ -543,6 +557,9 @@ subtest 'test 4' => sub {
      q{ && qc --check alignment_filter_metrics --filename_root 16839_7#7 --qc_in $PWD --qc_out } .$qc_out.q{ --rpt_list "16839:7:7" --input_files 16839_7#7_bam_alignment_filter_metrics.json}.
      q{ '};
 
+  apply_all_roles($hsx_gen, 'npg_pipeline::runfolder_scaffold');
+  $hsx_gen->create_product_level();
+
   my $da = $hsx_gen->generate();
   my $d = _find($da, 7, 7);
   is ($d->command, $command, 'command for HiSeqX run 16839 lane 7 tag 7');
@@ -600,6 +617,10 @@ subtest 'test 5' => sub {
     )
   } 'no error creating an object';
   is ($hs_gen->id_run, 16807, 'id_run inferred correctly');
+
+  apply_all_roles($hs_gen, 'npg_pipeline::runfolder_scaffold');
+  $hs_gen->create_product_level();
+
   my $da = $hs_gen->generate();
 
   my $qc_in  = qq{$bc_path/archive/lane6/plex1};
@@ -678,6 +699,9 @@ subtest 'test 6' => sub {
 
   is ($bait_gen->id_run, 20268, 'id_run inferred correctly');
 
+  apply_all_roles($bait_gen, 'npg_pipeline::runfolder_scaffold');
+  $bait_gen->create_product_level();
+
   my $da = $bait_gen->generate();
 
   my $qc_in  = qq{$bc_path/archive/lane1/plex1};
@@ -746,6 +770,10 @@ subtest 'test 7' => sub {
     )
   } 'no error creating an object';
   is ($ms_gen->id_run, 16850, 'id_run inferred correctly');
+
+  apply_all_roles($ms_gen, 'npg_pipeline::runfolder_scaffold');
+  $ms_gen->create_product_level();
+
   my $da = $ms_gen->generate();
 
   my $qc_in  = qq{$bc_path/archive/lane1/plex1};
@@ -815,6 +843,10 @@ subtest 'test 8' => sub {
     )
   } 'no error creating an object';
   is ($hs_gen->id_run, 16756, 'id_run inferred correctly');
+
+  apply_all_roles($hs_gen, 'npg_pipeline::runfolder_scaffold');
+  $hs_gen->create_product_level();
+
   my $da = $hs_gen->generate();
 
   my $qc_in  = qq{$bc_path/archive/lane1/plex1};
@@ -887,6 +919,10 @@ subtest 'test 9' => sub {
     )
   } 'no error creating an object';
   is ($ms_gen->id_run, 16866, 'id_run inferred correctly');
+
+  apply_all_roles($ms_gen, 'npg_pipeline::runfolder_scaffold');
+  $ms_gen->create_product_level();
+
   my $da = $ms_gen->generate();
 
   my $qc_in  = qq{$bc_path/archive/lane1/plex1};
@@ -959,6 +995,10 @@ subtest 'test 10' => sub {
     )
   } 'no error creating an object';
   is ($ms_gen->id_run, 20990, 'id_run (20990) inferred correctly');
+
+  apply_all_roles($ms_gen, 'npg_pipeline::runfolder_scaffold');
+  $ms_gen->create_product_level();
+
   my $da = $ms_gen->generate();
 
   my $qc_in  = qq{$bc_path/archive/lane1/plex1};
@@ -1029,6 +1069,10 @@ subtest 'test 11' => sub {
     )
   } 'no error creating an object';
   is ($chromium_gen->id_run, 16839, 'id_run inferred correctly');
+
+  apply_all_roles($chromium_gen, 'npg_pipeline::runfolder_scaffold');
+  $chromium_gen->create_product_level();
+
   my $da = $chromium_gen->generate();
 
   my $qc_in  = qq{$dir/150709_HX4_16839_A_H7MHWCCXX/Data/Intensities/BAM_basecalls_20150712-121006/no_cal/archive/lane1/plex1};
@@ -1098,6 +1142,10 @@ subtest 'test 12' => sub {
     )
   } 'no error creating an object';
   is ($ms_gen->id_run, 24135, 'id_run inferred correctly');
+
+  apply_all_roles($ms_gen, 'npg_pipeline::runfolder_scaffold');
+  $ms_gen->create_product_level();
+
   my $da = $ms_gen->generate();
 
   my $unique_string = $ms_gen->_job_id();

--- a/t/20-function-seq_alignment.t
+++ b/t/20-function-seq_alignment.t
@@ -21,7 +21,8 @@ use st::api::lims;
 use_ok('npg_pipeline::function::seq_alignment');
 
 my $odir    = abs_path cwd;
-my $dir     = tempdir( CLEANUP => 0);
+my $dir     = tempdir( CLEANUP => 1);
+
 my $logfile = join q[/], $dir, 'logfile';
 
 Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
@@ -187,6 +188,7 @@ subtest 'test 1' => sub {
   $rna_gen->create_product_level();
 
   my $da = $rna_gen->generate();
+
   ok ($da && @{$da} == 8, 'array of 8 definitions is returned');
 
   my $unique_string = $rna_gen->_job_id();

--- a/t/20-function-seqchksum_comparator.t
+++ b/t/20-function-seqchksum_comparator.t
@@ -55,11 +55,11 @@ my $archive_path = $recalibrated_path . q{/archive};
   ok (!$d->has_composition, 'no composition is not set');
   is ($d->job_name, q{seqchksum_comparator_1234_20100907-142417},
     'job_name is correct');
+  my $rp = $object->recalibrated_path;
   is ($d->command,
     q{npg_pipeline_seqchksum_comparator --id_run=1234 --lanes=1 --lanes=2} .
     qq{ --archive_path=$archive_path --bam_basecall_path=$bam_basecall_path} .
-    qq{ --input_globs=$archive_path/lane1/1234_1*.cram} .
-    qq{ --input_globs=$archive_path/lane2/1234_2*.cram},
+    qq{ --input_fofg_name=$rp/1234_input_fofn.txt},
     'command is correct');
   ok (!$d->excluded, 'step not excluded');
   ok (!$d->has_num_cpus, 'number of cpus is not set');

--- a/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane1/8747_bfs_fofn.txt
+++ b/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane1/8747_bfs_fofn.txt
@@ -1,0 +1,1 @@
+t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane1/qc

--- a/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane4/8747_bfs_fofn.txt
+++ b/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane4/8747_bfs_fofn.txt
@@ -1,0 +1,1 @@
+t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane4/qc

--- a/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane4/8747_sf_fofn.txt
+++ b/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane4/8747_sf_fofn.txt
@@ -1,0 +1,1 @@
+t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane4/qc

--- a/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane6/8747_bfs_fofn.txt
+++ b/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane6/8747_bfs_fofn.txt
@@ -1,0 +1,1 @@
+t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane6/qc

--- a/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane6/8747_sf_fofn.txt
+++ b/t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane6/8747_sf_fofn.txt
@@ -1,0 +1,1 @@
+t/data/example_runfolder/121103_HS29_08747_B_C1BV5ACXX/Data/Intensities/BAM_basecalls_20130122-085552/PB_cal_bam/archive/lane6/qc


### PR DESCRIPTION
use data products/rpt_list instead of run/lane/plex in stage1 and stage2 analysis

amend tests

add composition.json files to provide a simple way to determine the composition of data products produced by stage2 analysis (for example, to help with metadata determination when archiving)

small code adjustments because of new position of adapterfind in stage1 analysis (splice directives modified)