### PR TITLE
Destination aware irods publishing with clean history

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 LIST OF CHANGES
 ---------------
 
+ - publishing of seq data to iRODS:
+     make product destination aware;
+     iRODS directories hierarchy for NovaSeq runs to mirror product
+     archive directories hierarchy
+
 release 53.0
  - a wrapper object npg_pipeline::product to represent a product
  - use products attribute to drive p4_stage1, seq_alignment and autoqc

--- a/MANIFEST
+++ b/MANIFEST
@@ -53,6 +53,7 @@ lib/npg_pipeline/pluggable.pm
 lib/npg_pipeline/pluggable/central.pm
 lib/npg_pipeline/pluggable/registry.pm
 lib/npg_pipeline/product.pm
+lib/npg_pipeline/product/release/irods.pm
 lib/npg_pipeline/runfolder_scaffold.pm
 lib/npg_pipeline/validation/autoqc_files.pm
 lib/npg_pipeline/validation/common.pm

--- a/lib/npg_pipeline/function/seq_to_irods_archiver.pm
+++ b/lib/npg_pipeline/function/seq_to_irods_archiver.pm
@@ -7,7 +7,8 @@ use Readonly;
 use npg_pipeline::function::definition;
 
 extends qw{npg_pipeline::base};
-with    qw{npg_pipeline::function::util};
+with    qw{npg_pipeline::function::util
+           npg_pipeline::product::release::irods};
 
 our $VERSION = '0';
 

--- a/lib/npg_pipeline/product/release.pm
+++ b/lib/npg_pipeline/product/release.pm
@@ -298,12 +298,21 @@ sub _build_release_config {
 sub _find_study_config {
   my ($self, $product) = @_;
 
-  my $rpt      = $product->rpt_list();
-  my $name     = $product->file_name_root();
-  my $study_id = $product->lims->study_id();
+  my $with_spiked_control = 0;
+  my $rpt       = $product->rpt_list();
+  my $name      = $product->file_name_root();
+  #####
+  # If we were to process a pool as a single library, and all
+  # libraries in a pool belonged to the same study, passing
+  # false with_spiked_control flag will allow for retrieving
+  # a correct single study identifier. 
+  my @study_ids = $product->lims->study_ids($with_spiked_control);
 
-  $study_id or
+  @study_ids or
     $self->logconfess("Failed to get a study_id for product $name, $rpt");
+  (@study_ids == 1) or
+    $self->logconfess("Multiple study ids for product $name, $rpt");
+  my $study_id = $study_ids[0];
 
   my ($study_config) = grep { $_->{study_id} eq $study_id }
     @{$self->release_config->{study}};

--- a/lib/npg_pipeline/product/release/irods.pm
+++ b/lib/npg_pipeline/product/release/irods.pm
@@ -1,0 +1,86 @@
+package npg_pipeline::product::release::irods;
+
+use Moose::Role;
+use Readonly;
+
+requires qw/id_run platform_NovaSeq/;
+
+our $VERSION = '0';
+
+Readonly::Scalar my $IRODS_ROOT_NON_NOVASEQ_RUNS => q[/seq];
+Readonly::Scalar my $IRODS_ROOT_NOVASEQ_RUNS     => q[/seq/illumina/runs];
+
+has 'irods_destination_collection' => (
+  isa           => 'Str',
+  is            => 'ro',
+  required      => 0,
+  lazy_build    => 1,
+  documentation => 'iRODS destination collection for run product data',
+);
+sub _build_irods_destination_collection {
+  my $self = shift;
+  return join q[/],
+    $self->platform_NovaSeq() ? $IRODS_ROOT_NOVASEQ_RUNS : $IRODS_ROOT_NON_NOVASEQ_RUNS,
+    $self->id_run;
+}
+
+no Moose::Role;
+
+1;
+
+__END__
+
+=head1 NAME
+
+npg_pipeline::product::release::irods
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Moose role providing utility methods for iRODS context
+
+=head1 SUBROUTINES/METHODS
+
+=head2 irods_destination_collection
+
+Returns iRODS destination collection for the run.
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose::Role
+
+=item Readonly
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Marina Gourtovaia
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2019 Genome Research Ltd.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/lib/npg_pipeline/product/release/irods.pm
+++ b/lib/npg_pipeline/product/release/irods.pm
@@ -5,13 +5,6 @@ use Readonly;
 
 with 'npg_pipeline::product::release' => {
        -alias    => { is_for_release => '_is_for_release' },
-       -excludes => [ qw/qc_schema
-                         customer_name
-                         is_for_s3_release
-                         s3_url
-                         s3_profile
-                         is_for_s3_release_notification
-                         is_for_X_release/ ]
      };
 
 requires qw/ 

--- a/t/20-function-s3_archiver.t
+++ b/t/20-function-s3_archiver.t
@@ -6,12 +6,15 @@ use File::Copy;
 use File::Path qw[make_path];
 use File::Temp;
 use Log::Log4perl qw[:levels];
+use File::Temp qw[tempdir];
 use Test::More tests => 4;
 use Test::Exception;
 use t::util;
 
+my $temp_dir = tempdir(CLEANUP => 1);
 Log::Log4perl->easy_init({level  => $INFO,
-                          layout => '%d %p %m %n'});
+                          layout => '%d %p %m %n',
+                          file   => join(q[/], $temp_dir, 'logfile')});
 
 {
   package TestDB;

--- a/t/20-function-seq_to_irods_archiver.t
+++ b/t/20-function-seq_to_irods_archiver.t
@@ -3,6 +3,8 @@ use warnings;
 use Test::More tests => 3;
 use Test::Exception;
 use File::Copy;
+use Log::Log4perl qw[:levels];
+use File::Slurp;
 use t::util;
 
 use_ok('npg_pipeline::function::seq_to_irods_archiver');
@@ -11,11 +13,24 @@ my $util = t::util->new();
 
 my $tmp_dir = $util->temp_directory();
 my $script = q{npg_publish_illumina_run.pl};
+my $config_dir = join q[/], $tmp_dir, 'config';
+mkdir $config_dir;
+copy 't/data/release/config/archive_on/product_release.yml', $config_dir;
+copy 'data/config_files/general_values.ini', $config_dir;
+my $pconfig = join q[/], $config_dir, 'product_release.yml';
+
+Log::Log4perl->easy_init({level  => $INFO,
+                          layout => '%d %p %m %n',
+                          file   => join(q[/], $tmp_dir, 'logfile')});
 
 subtest 'MiSeq run' => sub {
-  plan tests => 33;
+  plan tests => 41;
 
   local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q{t/data/miseq/samplesheet_16850.csv};
+  my $pconfig_content = read_file $pconfig;
+  my $study_id = 3573;
+  ok ($pconfig_content !~ /study_id: \"$study_id\"/xms,
+    'no product release config for this run study');
 
   my $id_run  = 16850;
   my $rf_name = '150710_MS2_16850_A_MS3014507-500V2';
@@ -35,11 +50,12 @@ subtest 'MiSeq run' => sub {
   my $restart_file = qr/${archive_path}\/publish_seq_data2irods_${id_run}_20181204-\d+\.restart_file\.json/;
 
   my $a = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204}
-  );
+    run_folder     => $rf_name,
+    runfolder_path => $rfpath,
+    conf_path      => $config_dir,
+    id_run         => $id_run,
+    timestamp      => q{20181204}
+   );
   isa_ok($a, q{npg_pipeline::function::seq_to_irods_archiver}, q{object test});
   ok (!$a->no_irods_archival, 'no_irods_archival flag is unset');
 
@@ -54,9 +70,45 @@ subtest 'MiSeq run' => sub {
   is ($d->identifier, $id_run, 'identifier is set correctly');
   is ($d->job_name, qq{publish_seq_data2irods_${id_run}_20181204},
     'job_name is correct');
+
+  like ($d->command, qr/\Abash -c 'set -e;/, 'correct command start');
   like ($d->command,
-    qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path/,
-    'command is correct');
+    qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path\/lane1\/plex0;/,
+    'contains command for tag zero');
+  like ($d->command,
+     qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path\/lane1\/plex1;/,
+    'contains command for tag 1');
+  like ($d->command,
+     qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path\/lane1\/plex2/,
+    'contains command for tag 2');
+  like ($d->command, qr/plex2'\Z/, 'correct command end');
+
+  # Make study explicitly configured to be archived to iRODS
+  $pconfig_content =~ s/study_id: \"1000\"/study_id: \"$study_id\"/;
+  write_file($pconfig, $pconfig_content);
+
+  $a = npg_pipeline::function::seq_to_irods_archiver->new(
+    run_folder     => $rf_name,
+    runfolder_path => $rfpath,
+    conf_path      => $config_dir,
+    id_run         => $id_run,
+    timestamp      => q{20181204}
+  );
+
+  $da = $a->create();
+  $d = $da->[0];
+  like ($d->command, qr/\Abash -c 'set -e;/, 'correct command start');
+  like ($d->command,
+    qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path\/lane1\/plex0;/,
+    'contains command for tag zero');
+  like ($d->command,
+     qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path\/lane1\/plex1;/,
+    'contains command for tag 1');
+  like ($d->command,
+     qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path\/lane1\/plex2/,
+    'contains command for tag 2');
+  like ($d->command, qr/plex2'\Z/, 'correct command end');
+
   is ($d->command_preexec,
     'npg_pipeline_script_must_be_unique_runner -job_name="publish_seq_data2irods_16850"',
     'preexec command is correct');
@@ -71,7 +123,8 @@ subtest 'MiSeq run' => sub {
 
   $a = npg_pipeline::function::seq_to_irods_archiver->new(
     run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
+    runfolder_path    => $rfpath,
+    conf_path         => $config_dir,  
     id_run            => $id_run,
     timestamp         => q{20181204},
     no_irods_archival => 1
@@ -84,11 +137,12 @@ subtest 'MiSeq run' => sub {
   ok ($d->excluded, 'step is excluded');
 
   $a = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204},
-    local              => 1
+    run_folder     => $rf_name,
+    runfolder_path => $rfpath,
+    conf_path      => $config_dir,
+    id_run         => $id_run,
+    timestamp      => q{20181204},
+    local          => 1
   );
   ok ($a->no_irods_archival, 'no_irods_archival flag is set');
   $da = $a->create();
@@ -96,46 +150,34 @@ subtest 'MiSeq run' => sub {
   $d = $da->[0];
   ok ($d->excluded, 'step is excluded');
 
-  $a  = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204},
-    lanes             => [1]
+  $a = npg_pipeline::function::seq_to_irods_archiver->new(
+    run_folder       => $rf_name,
+    runfolder_path   => $rfpath,
+    conf_path        => $config_dir,
+    id_run           => $id_run,
+    timestamp        => q{20181204},
+    id_flowcell_lims => q{1023456789111}
   );
   $da = $a->create();
   ok ($da && @{$da} == 1, 'an array with one definition is returned');
   $d = $da->[0];
   like ($d->command,
-    qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path/,
-    'command is correct');
+    qr/$script --restart_file $restart_file --max_errors 10 --alt_process qc_run --collection $col --source_directory $archive_path\/lane1\/plex0/,
+    'command is correct for qc run');
 
   $a = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204},
-    id_flowcell_lims  => q{1023456789111}
+    run_folder       => $rf_name,
+    runfolder_path   => $rfpath,
+    conf_path        => $config_dir,  
+    id_run           => $id_run,
+    timestamp        => q{20181204},
+    lims_driver_type => 'samplesheet'
   );
   $da = $a->create();
   ok ($da && @{$da} == 1, 'an array with one definition is returned');
   $d = $da->[0];
   like ($d->command,
-    qr/$script --restart_file $restart_file --max_errors 10 --alt_process qc_run --collection $col --source_directory $archive_path/,
-    'command is correct');
-
-  $a = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204},
-    lims_driver_type  => 'samplesheet'
-  );
-  $da = $a->create();
-  ok ($da && @{$da} == 1, 'an array with one definition is returned');
-  $d = $da->[0];
-  like ($d->command,
-    qr/$script --restart_file $restart_file --max_errors 10 --driver-type samplesheet --collection $col --source_directory $archive_path/,
+    qr/$script --restart_file $restart_file --max_errors 10 --driver-type samplesheet --collection $col --source_directory $archive_path\/lane1\/plex0/,
     'command is correct');
 };
 
@@ -154,33 +196,35 @@ subtest 'NovaSeq run' => sub {
     qq{$bbc_path/metadata_cache_26291/samplesheet_26291.csv};
 
   my $a  = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204}
+    run_folder     => $rf_name,
+    runfolder_path => $rfpath,
+    conf_path      => $config_dir,  
+    id_run         => $id_run,
+    timestamp      => q{20181204}
   );
   my $da = $a->create();
   ok ($da && @{$da} == 1, 'an array with one definition is returned');
   my $d = $da->[0];
   isa_ok($d, q{npg_pipeline::function::definition});
   like ($d->command,
-    qr/$script --restart_file $restart_file --max_errors 10 --collection $col --source_directory $archive_path/,
-    'command is correct');
+    qr/$script --restart_file $restart_file --max_errors 10 --collection $col\/plex0 --source_directory $archive_path\/plex0;$script --restart_file $restart_file --max_errors 10 --collection $col\/plex888 --source_directory $archive_path\/plex888/,
+    'command is correct for merged lanes');
 
   $a  = npg_pipeline::function::seq_to_irods_archiver->new(
-    run_folder        => $rf_name,
-    runfolder_path    => $rfpath,  
-    id_run            => $id_run,
-    timestamp         => q{20181204}, 
-    lanes             => [2]
+    run_folder     => $rf_name,
+    runfolder_path => $rfpath,
+    conf_path      => $config_dir,
+    id_run         => $id_run,
+    timestamp      => q{20181204}, 
+    lanes          => [2]
   );
 
   $da = $a->create();
   ok ($da && @{$da} == 1, 'an array with one definition is returned');
   $d = $da->[0];
   like ($d->command,
-    qr/$script --restart_file $restart_file --max_errors 10 --positions 2 --collection $col --source_directory $archive_path/,
-    'command is correct');
+    qr/$script --restart_file $restart_file --max_errors 10 --collection $col\/lane2\/plex0 --source_directory $archive_path\/lane2\/plex0;$script --restart_file $restart_file --max_errors 10 --collection $col\/lane2\/plex888 --source_directory $archive_path\/lane2\/plex888/,
+    'command is correct for a single lane');
 };
 
 1;


### PR DESCRIPTION
For every product that is eligible for iRODS archival a separate definition is created. On LSF this translates to a job aray where only one job will be executed at a time, ie no parallelism. Under wr similar functionality can be achieved with a local manager with one CPU available to it. There is also an option to bunch all commands together into one job, this would be triggered by the array_cpu_limit apply_array_cpu_limit attribute of the job definition for all array members being set to 1 (this settings trigger %1 added to the LSF job name).

This pr was tested by archiving one tile of data to dev iRODS from a new-style run folder on seq. farm.