### PR TITLE
Ensure the interop files go to a dedicated directory.

### DIFF
--- a/lib/npg_pipeline/function/run_data_to_irods_archiver.pm
+++ b/lib/npg_pipeline/function/run_data_to_irods_archiver.pm
@@ -26,7 +26,7 @@ override 'create' => sub {
       $PUBLISH_SCRIPT_NAME,
       q{--restart_file},     $self->restart_file_path($job_name_prefix),
       q{--max_errors},       $self->num_max_errors(),
-      q{--collection},       $self->irods_destination_collection(),
+      q{--collection},       $self->irods_destination_collection() . '/InterOp',
       q{--source_directory}, $self->runfolder_path(),
       q{--include},          q['RunInfo.xml'],
       q{--include},          q['[Rr]unParameters.xml'],

--- a/t/20-function-run_data_to_irods_archiver.t
+++ b/t/20-function-run_data_to_irods_archiver.t
@@ -32,7 +32,7 @@ subtest 'MiSeq run' => sub {
     ok($copied, "$name copied");
   }
   my $archive_path = $paths->{'archive_path'};
-  my $col = qq{/seq/$id_run};
+  my $col = qq{/seq/$id_run/InterOp};
   my $restart_file = qr/${archive_path}\/publish_run_data2irods_${id_run}_20181204-\d+\.restart_file\.json/;
 
   my $a = npg_pipeline::function::run_data_to_irods_archiver->new(
@@ -106,7 +106,7 @@ subtest 'NovaSeq run' => sub {
   my $rfpath  = qq{t/data/novaseq/$rf_name};
   my $bbc_path = qq{$rfpath/Data/Intensities/BAM_basecalls_20180805-013153};
   my $archive_path = qq{$bbc_path/no_cal/archive};
-  my $col = qq{/seq/illumina/runs/$id_run};
+  my $col = qq{/seq/illumina/runs/$id_run/InterOp};
   my $restart_file = qr/${archive_path}\/publish_run_data2irods_${id_run}_20181204-\d+\.restart_file\.json/;
 
   local $ENV{NPG_CACHED_SAMPLESHEET_FILE} =


### PR DESCRIPTION
Unfortunately, RunInfi and RunParams will go to the
interop dir as well.