### PR TITLE
set explicit umask for wr jobs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 ---------------
 
+release 54.1.2
+ - set explicit umask for wr jobs to guarantee that output is group-writable
+
 release 54.1.1
  - bug fix in command generation for iRODS data archival from old-style
    run folders

--- a/lib/npg_pipeline/executor/wr.pm
+++ b/lib/npg_pipeline/executor/wr.pm
@@ -201,7 +201,7 @@ sub _definition4job {
     return;
   };
 
-  my $command = join q[ ], q[(], $d->command(), q[)], q[2>&1];
+  my $command = join q[ ], q[(umask 0002 &&], $d->command(), q[)], q[2>&1];
   my $lf = $log_file->();
   if ($lf) {
     #####

--- a/t/30-executor-wr.t
+++ b/t/30-executor-wr.t
@@ -109,7 +109,7 @@ subtest 'definition for a job' => sub {
   );
 
   my $job_def = $e->_definition4job('pipeline_wait4path', 'some_dir', $fd);
-  my $expected = { 'cmd' => '( /bin/true ) 2>&1',
+  my $expected = { 'cmd' => '(umask 0002 && /bin/true ) 2>&1',
                    'cpus' => 1,
                    'priority' => 0,
                    'memory' => '2000M' };
@@ -119,7 +119,7 @@ subtest 'definition for a job' => sub {
   $ref->{'memory'}   = 100;
   $fd = npg_pipeline::function::definition->new($ref);
   $expected = {
-    'cmd' => '( /bin/true ) 2>&1 | tee -a "some_dir/pipeline_start-today-1234.out"',
+    'cmd' => '(umask 0002 && /bin/true ) 2>&1 | tee -a "some_dir/pipeline_start-today-1234.out"',
     'cpus' => 0,
     'priority' => 0,
     'memory'   => '100M' };


### PR DESCRIPTION
Patch to master to be released on OS ASAP.
Tested by manual edit of a file that is used in wr add -f command for wr manager running with a cloud config option. The jobs create output files that are writable for a group.