### PR TITLE
Add chunk information to log file name

### DIFF
--- a/lib/npg_pipeline/executor/wr.pm
+++ b/lib/npg_pipeline/executor/wr.pm
@@ -221,7 +221,7 @@ sub _definition4job {
     if ($function_name ne 'pipeline_wait4path') {
       my $log_name = join q[-], $function_name, $d->created_on(),
         $d->has_composition() ? $d->composition()->freeze2rpt () : $d->identifier();
-      $log_name   .= q[.out];
+      $log_name   .= $d->chunk_label.q[.out];
       return join q[/], $log_dir, $log_name;
     }
     return;

--- a/lib/npg_pipeline/function/haplotype_caller.pm
+++ b/lib/npg_pipeline/function/haplotype_caller.pm
@@ -134,7 +134,8 @@ sub create {
            'num_hosts'    => $NUM_HOSTS,
            'num_cpus'     => [$CPUS],
            'memory'       => $MEMORY,
-           'composition'  => $product->composition());
+           'composition'  => $product->composition(),
+           'chunk'        => $product->chunk);
     }
   }
 

--- a/t/30-executor-wr.t
+++ b/t/30-executor-wr.t
@@ -90,7 +90,7 @@ subtest 'wr add command' => sub {
 };
 
 subtest 'definition for a job' => sub {
-  plan tests => 2;
+  plan tests => 3;
 
   my $ref = {
     created_by    => __PACKAGE__,
@@ -128,6 +128,16 @@ subtest 'definition for a job' => sub {
     'memory'   => '100M' };
   $job_def = $e->_definition4job('pipeline_start', 'some_dir', $fd);
   is_deeply ($job_def, $expected, 'job definition with tee-ing to a log file');
+
+  $ref->{'chunk'} = 1;
+  $fd = npg_pipeline::function::definition->new($ref);
+  $expected = {
+    'cmd' => '(umask 0002 && /bin/true ) 2>&1 | tee -a "some_dir/pipeline_start-today-1234.1.out"',
+    'cpus' => 0,
+    'priority' => 0,
+    'memory'   => '100M' };
+  $job_def = $e->_definition4job('pipeline_start', 'some_dir', $fd);
+  is_deeply ($job_def, $expected, 'chunked job definition with tee-ing to a log file');
 };
 
 subtest 'dependencies' => sub {


### PR DESCRIPTION
Previously chunks were accidentally sharing a log file. This is undesirable and confusing.