### PR TITLE
add -f to rm command

### DIFF
--- a/lib/npg_pipeline/function/remove_intermediate_data.pm
+++ b/lib/npg_pipeline/function/remove_intermediate_data.pm
@@ -51,7 +51,7 @@ sub create {
   my $recal_path = $self->recalibrated_path;
   if(not $recal_path) { $self->logcroak('unable to determine recalibrated path for intermediate data deletion'); }
 
-  my $command = sprintf q[rm -v %s/*.cram], $recal_path;
+  my $command = sprintf q[rm -fv %s/*.cram], $recal_path;
 
   return [
       npg_pipeline::function::definition->new(

--- a/t/20-function-remove_intermediate_data.t
+++ b/t/20-function-remove_intermediate_data.t
@@ -11,7 +11,7 @@ my $o=npg_pipeline::function::remove_intermediate_data->new(
 );
 my $defs = $o->create;
 
-my $expected_command = q[rm -v /a/recalibrated/path/no_cal/*.cram];
+my $expected_command = q[rm -fv /a/recalibrated/path/no_cal/*.cram];
 
 ok ($defs && @{$defs} == 1, 'array of 1 definition is returned');
 my $def = $defs->[0];


### PR DESCRIPTION
add -f to rm command when removing intermediate cram files to avoid error and job failure when no intermediate crams are present