### PR TITLE
Groups limits for wr executor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 LIST OF CHANGES
 ---------------
 
+ - ability to apply limits to wr groups of jobs and a limit for
+   all iRODS jobs
  - function creating definitions for autoqc jobs - when evaluating
    whether the autoqc check should be run:
      reduce run time by passing to the autoqc class instance,

--- a/data/config_files/wr.json
+++ b/data/config_files/wr.json
@@ -2,5 +2,6 @@
  "default_queue":{},
  "small_queue":{},
  "lowload_queue":{},
- "p4stage1_queue":{"cloud_flavor":"ukb1.2xlarge"}
+ "p4stage1_queue":{"cloud_flavor":"ukb1.2xlarge"},
+ "limit_grps":{"irods":3}
 }

--- a/lib/npg_pipeline/function/seq_to_irods_archiver.pm
+++ b/lib/npg_pipeline/function/seq_to_irods_archiver.pm
@@ -44,8 +44,6 @@ sub create {
     foreach my $product (@{$self->products->{'data_products'}}) {
       if ($self->is_for_irods_release($product)) {
         my %dref = %{$ref};
-        $dref{'array_cpu_limit'}       = 1; # One job at a time
-        $dref{'apply_array_cpu_limit'} = 1;
         $dref{'composition'}           = $product->composition;
         $dref{'command'} = sprintf '%s --restart_file %s --collection %s --source_directory %s',
           $command,

--- a/t/20-function-seq_to_irods_archiver.t
+++ b/t/20-function-seq_to_irods_archiver.t
@@ -27,7 +27,7 @@ Log::Log4perl->easy_init({level  => $INFO,
                           file   => join(q[/], $tmp_dir, 'logfile')});
 
 subtest 'MiSeq run' => sub {
-  plan tests => 46;
+  plan tests => 44;
 
   local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q{t/data/miseq/samplesheet_16850.csv};
   my $pconfig_content = read_file $pconfig;
@@ -127,8 +127,6 @@ subtest 'MiSeq run' => sub {
   is ($d->queue, 'lowload', 'queue');
   is ($d->fs_slots_num, 1, 'one fs slot is set');
   ok ($d->reserve_irods_slots, 'iRODS slots to be reserved');
-  is ($d->array_cpu_limit, 1, 'array cpu limit is 1');
-  ok ($d->apply_array_cpu_limit, 'apply array cpu limit is set');
   lives_ok {$d->freeze()} 'definition can be serialized to JSON';
 
   $a = npg_pipeline::function::seq_to_irods_archiver->new(


### PR DESCRIPTION
This pr also removes array_cpu_limit for LSF jobs as a separate commit. This was used to avoid contention on lane collections creation, which, as @kjsanger has shown, is not a problem