### PR TITLE
Archiver4climb

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -64,6 +64,7 @@ my $builder = $class->new(
           'Readonly'                     => 1.03,
           'strict'                       => 1.03,
           'Sys::Filesystem::MountPoint'  => 0,
+          'Text::CSV'                    => 0,
           'Try::Tiny'                    => 0,
           'UUID'                         => 0,
           'URI'                          => 0,

--- a/MANIFEST
+++ b/MANIFEST
@@ -53,6 +53,7 @@ lib/npg_pipeline/function/log_files_archiver.pm
 lib/npg_pipeline/function/merge_recompress.pm
 lib/npg_pipeline/function/p4_stage1_analysis.pm
 lib/npg_pipeline/function/stage2pp.pm
+lib/npg_pipeline/function/pp_archiver.pm
 lib/npg_pipeline/function/product_delivery_notifier.pm
 lib/npg_pipeline/function/run_data_to_irods_archiver.pm
 lib/npg_pipeline/function/s3_archiver.pm
@@ -123,6 +124,7 @@ t/20-function-log_files_archiver.t
 t/20-function-merge_recompress.t
 t/20-function-p4_stage1_analysis.t
 t/20-function-stage2pp.t
+t/20-function-pp_archiver.t
 t/20-function-product_delivery_notifier.t
 t/20-function-run_data_to_irods_archiver.t
 t/20-function-s3_archiver.t
@@ -1045,6 +1047,7 @@ t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a/product_release.yml
 t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a/product_release_no_pp.yml
 t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a/product_release_no_study.yml
 t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a/product_release_unknown_pp.yml
+t/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_no_staging_root.yml
 t/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_two_pps.yml
 t/data/products/samplesheet_novaseq4lanes.csv
 t/data/products/samplesheet_rapidrun_nopool.csv

--- a/lib/npg_pipeline/function/pp_archiver.pm
+++ b/lib/npg_pipeline/function/pp_archiver.pm
@@ -1,0 +1,378 @@
+package npg_pipeline::function::pp_archiver;
+
+use Moose;
+use MooseX::StrictConstructor;
+use namespace::autoclean;
+use Text::CSV qw/csv/;
+use File::Spec::Functions;
+use File::Basename;
+use Readonly;
+
+use npg_qc::Schema;
+use npg_pipeline::function::definition;
+
+extends 'npg_pipeline::base';
+with qw/ npg_pipeline::product::release
+         npg_pipeline::product::release::portable_pipeline /;
+with 'npg_common::roles::software_location' => { tools => [qw/npg_upload2climb/] };
+
+our $VERSION = '0';
+
+Readonly::Scalar my $MANIFEST_PATH_ENV_VAR => q[NPG_MANIFEST4PP_FILE];
+Readonly::Scalar my $MANIFEST_PREFIX       => q[manifest4pp_upload];
+
+Readonly::Scalar my $PP_NAME               => q[ncov2019-artic-nf];
+Readonly::Scalar my $PP_DATA_GLOB          =>
+                    catfile(q[qc_pass_climb_upload], q[*], q[*], q[*{am,fa}]);
+
+=head1 NAME
+
+npg_pipeline::function::pp_archiver
+
+=head1 SYNOPSIS
+
+  my $archiver = npg_pipeline::function::pp_archiver->new(
+                 runfolder_path => $my_path);
+
+  # to generate a manifest and create a job definition
+  my $definitions = $archiver->create();
+  my $d = $definitions->[0];
+  print $d->excluded;
+
+  # to generate a manifest
+  $archiver->generate_manifest();
+
+=head1 DESCRIPTION
+
+This class provides two public methods, create() and
+generate_manifest(), which can serve as callbacks to
+for pipeline's functions. Please refer to the methods'
+documentation for their functionality.
+
+The class is meant to set the sceen for the upload of data,
+produced by portable pipelines, to third-party archives.
+
+The current implementation is not generic, it focuses on
+dealing with data for the ncov2019-artic-nf pipeline.
+
+Both create and generate_manifest methods generate a
+manifest, a tab-separated file, containing a header and
+sufficient product data for further upload to a third-party
+archive.
+
+If the env variable NPG_MANIFEST4PP_FILE is set, the value of
+the variable is interpreted as a path of the manifest file.
+If the file does not exist, it is created. By default the manifest
+is created in the analysis directory of the run folder, its
+name starts with 'manifest4pp_upload'. A new file with a unique
+name is generated on each execution of either of the methods.
+
+Criteria for products to be included into the  manifest:
+the portable pipeline is flagged for external archival and
+a user (utility) QC outcome for this product exists and is
+set to 'Accepted'.
+
+=cut
+
+=head1 SUBROUTINES/METHODS
+
+=cut
+
+=head2 npg_upload2climb_cmd
+
+An absolute path to the command.
+
+=head2 qc_schema
+
+Lazy-build DBIx schema object for the QC database,
+inherited from npg_pipeline::base and changed to
+be lazy.
+
+=cut
+
+has '+qc_schema' => (
+  lazy       => 1,
+  builder    => '_build_qc_schema',
+);
+sub _build_qc_schema {
+  return npg_qc::Schema->connect();
+}
+
+=head2 create
+
+Returns an array containing a single npg_pipeline::function::definition
+object. When no products are to be archived, the 'excluded' attribute of
+the object is set to true, otherwise this attribute is set to false and
+the 'command' attribute is set. Running this command should archive all
+portable pipeline products to their destinations.
+
+While this method is running, it creates a manifest file, which can be
+used by the generated command to infer what products have to be archived
+and their location in the run folder.
+
+For now only products belonging to the ncov2019-artic-nf pipeline are
+considered.
+
+=cut
+
+sub create {
+  my $self = shift;
+
+  my $ref =  {created_by => __PACKAGE__,
+              created_on => $self->timestamp(),
+              identifier => $self->label};
+
+  my @sample_names = sort keys %{$self->_products4upload};
+  if (@sample_names) {
+    $ref->{'job_name'} = join q[_], 'pp_archiver', $self->label();
+    $ref->{'command'}  = join q[ ], $self->npg_upload2climb_cmd,
+                                    $self->_manifest_path;
+    $self->_generate_manifest4archiver();
+  } else {
+    $self->debug('No pp data to archive, skipping');
+    $ref->{'excluded'} = 1;
+  }
+
+  return [npg_pipeline::function::definition->new($ref)];
+}
+
+=head2 generate_manifest
+
+Returns an array containing a single npg_pipeline::function::definition
+object, which has the 'excluded' attribute set to true. No command for 
+later execution is generated. While this method is running, it creates
+a manifest file, listing the products due to be archived their location
+in the run folder.
+
+For now only products belonging to the ncov2019-artic-nf pipeline are
+considered.
+
+=cut
+
+sub generate_manifest {
+  my $self = shift;
+
+  $self->_generate_manifest4archiver();
+
+  # No need to create a job, the only purpose of this function is
+  # to generate the manifest.
+  return [ npg_pipeline::function::definition->new(
+              created_by => __PACKAGE__,
+              created_on => $self->timestamp(),
+              identifier => $self->label,
+              excluded   => 1) ];
+}
+
+sub _generate_manifest4archiver {
+  my $self = shift;
+
+  my $path = $ENV{$MANIFEST_PATH_ENV_VAR};
+  if ($path and -f $path) {
+    $self->info(sprintf 'Existing manifest %s will be used', $path);
+    return;
+  } else {
+    $self->info(sprintf 'A new manifest %s will be created', $self->_manifest_path);
+  }
+
+  # In the context of one run the third column of the manifest is redundant.
+  # However, this would help to deal with ad-hock situations.
+
+  my @lines = ();
+  foreach my $sname (sort keys %{$self->_products4upload}) {
+    my $cached = $self->_products4upload->{$sname};
+    my $c = $cached->{'product'}->composition;
+    push @lines, [$sname,
+                  $cached->{'pp_data_glob'},
+                  $self->_staging_archive_path,
+                  $c->freeze(),
+                  $c->digest()];
+  }
+
+  my $num_lines = @lines;
+  # add header
+  unshift @lines, [qw/sample_name files_glob staging_archive_path product_json id_product/];
+
+  if ($num_lines == 0) {
+    $self->warn('Nothing to archive, am empty manifest will be generated');
+  }
+  $self->info('Writing manifest to ' . $self->_manifest_path);
+  csv(in => \@lines, out => $self->_manifest_path, strict => 1,
+      sep_char => qq[\t], eol => qq[\n],
+      quote_char => undef, escape_char => undef);
+
+  return $num_lines;
+}
+
+has '_products4upload' => (
+  isa        => q{HashRef},
+  is         => q{ro},
+  lazy_build => 1,
+);
+sub _build__products4upload {
+  my $self = shift;
+
+  my $p_config = $self->_pipeline_config();
+  $p_config or return {};
+
+  my $short_id = $self->pp_short_id($p_config);
+
+  my @products = grep { $self->is_release_data($_) }
+                 @{$self->products->{data_products}};
+
+  my $products4archive = {};
+
+  foreach my $product (@products) {
+
+    my $archival_flag = grep { $self->pp_short_id($_) eq $short_id }
+                        @{$self->pps_config4product($product)};
+    $archival_flag or next;
+
+    my $sname = $product->lims->sample_supplier_name;
+    $sname or $self->logcroak('Sample supplier name is not defined');
+
+    # UQC outcomes are not set for controls, so internal controls
+    # are filtered out at this stage, alingside with QC failures.
+    my $uqc = $product->uqc_obj($self->qc_schema);
+    ($uqc && $uqc->is_accepted) or next;
+
+    # First come basis for choosing one of the duplicates.
+    if ($products4archive->{$sname}) {
+      $self->logwarn("Already cached sample $sname for sending, skipping");
+      next;
+    }
+
+    $products4archive->{$sname}->{'product'} = $product;
+
+    # Where are the files to upload?
+    my $dir = $self->pp_archive4product($product, $p_config, $self->pp_archive_path);
+    $products4archive->{$sname}->{'pp_data_glob'} = catdir($dir, $PP_DATA_GLOB);
+  }
+
+  return $products4archive;
+}
+
+has '_pipeline_config' => (
+  isa        => q{Maybe[HashRef]},
+  is         => q{ro},
+  lazy_build => 1,
+ );
+sub _build__pipeline_config {
+  my $self = shift;
+
+  my @products = grep { $self->is_release_data($_) }
+                 @{$self->products->{data_products}};
+
+  my $pps4archival = {};
+  foreach my $product (@products) {
+    my @pps = grep { $self->pp_enable_external_archival($_) }
+              grep { $self->pp_name($_) eq $PP_NAME }
+              @{$self->pps_config4product($product)};
+    @pps or next;
+    foreach my $pp (@pps) {
+      push @{$pps4archival->{$self->pp_short_id($pp)}}, $pp;
+    }
+  }
+
+  my @pipeline_ids = keys %{$pps4archival};
+  my $config;
+  if (@pipeline_ids) {
+    if (@pipeline_ids > 1) {
+      $self->logcroak('Multiple external archives are not supported');
+    }
+    $config = $pps4archival->{$pipeline_ids[0]}->[0];
+    $self->pp_staging_root($config); # validates
+  }
+
+  return $config;
+}
+
+has '_staging_archive_path' => (
+  isa        => q{Str},
+  is         => q{ro},
+  lazy_build => 1,
+);
+sub _build__staging_archive_path {
+  my $self = shift;
+  # PP_STAGING_ROOT/RUN_ID/ANALYSIS_DIR_NAME/RUN_FOLDER_NAME
+  my ($dir_name) = fileparse($self->analysis_path);
+  return catdir($self->pp_staging_root($self->_pipeline_config),
+                $self->id_run,
+                $dir_name,
+		$self->run_folder);
+}
+
+has '_manifest_path' => (
+  isa        => q{Str},
+  is         => q{ro},
+  lazy_build => 1,
+);
+sub _build__manifest_path {
+  my $self = shift;
+
+  my $path = $ENV{$MANIFEST_PATH_ENV_VAR};
+  if (not defined $path) {
+    $path = join q[_], $MANIFEST_PREFIX, $self->label(), $self->random_string();
+    $path = catfile($self->analysis_path, $path . q[.tsv]);
+  }
+
+  return $path;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item MooseX::StrictConstructor
+
+=item namespace::autoclean
+
+=item Text::CSV
+
+=item File::Spec::Functions
+
+=item File::Basename
+
+=item Readonly
+
+=item npg_qc::Schema
+
+=item npg_common::roles::software_location
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Marina Gourtovaia
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2020 Genome Research Ltd.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/lib/npg_pipeline/pluggable/registry.pm
+++ b/lib/npg_pipeline/pluggable/registry.pm
@@ -47,10 +47,12 @@ Readonly::Hash my %REGISTRY => (
   'haplotype_caller'        => {'haplotype_caller' => 'create'},
   'merge_recompress'        => {'merge_recompress' => 'create'},
 
-  'archive_logs'                            => {'log_files_archiver' => 'create'},
-  'upload_auto_qc_to_qc_database'           => {'autoqc_archiver' => 'create'},
-  'archive_run_data_to_irods'               => {'run_data_to_irods_archiver' => 'create'},
-  'remove_intermediate_data'                => {'remove_intermediate_data' => 'create'},
+  'archive_logs'                   => {'log_files_archiver' => 'create'},
+  'upload_auto_qc_to_qc_database'  => {'autoqc_archiver' => 'create'},
+  'archive_run_data_to_irods'      => {'run_data_to_irods_archiver' => 'create'},
+  'remove_intermediate_data'       => {'remove_intermediate_data' => 'create'},
+  'pp_archiver'                    => {'pp_archiver' => 'create'},
+  'pp_archiver_manifest'           => {'pp_archiver' => 'generate_manifest'},
 
   'bam_cluster_counter_check'=> {'cluster_count' => 'create'},
   'seqchksum_comparator'     => {'seqchksum_comparator' => 'create'},

--- a/lib/npg_pipeline/product.pm
+++ b/lib/npg_pipeline/product.pm
@@ -656,28 +656,6 @@ sub final_libqc_obj {
   return;
 }
 
-=head2 uqc_obj
-
-  Returns a DBIx row object representing a utility (user) QC outcome.
-  Returns an undefined value if the this type of QC outcome is not
-  available for this product.
-
-  npg_qc::Schema object argument is required.
-
-    my $uqc_obj = $p->uqc_obj($schema);
-    print $uqc_obj->is_accepted;
-
-=cut
-
-sub uqc_obj {
-  my ($self, $schema) = @_;
-
-  $schema or croak 'qc schema argument is required';
-
-  return $schema->resultset('UqcOutcomeEnt')
-                ->search_via_composition([$self->composition])->next;
-}
-
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/npg_pipeline/product.pm
+++ b/lib/npg_pipeline/product.pm
@@ -632,7 +632,7 @@ sub final_seqqc_objs {
 =head2 final_libqc_obj
 
   Returns a DBIx row object representing a final library QC outcome.
-  Returns an undefined value if the the final library QC outcome is
+  Returns an undefined value if the final library QC outcome is
   not available for this product.
 
   npg_qc::Schema object argument is required.
@@ -654,6 +654,28 @@ sub final_libqc_obj {
   }
 
   return;
+}
+
+=head2 uqc_obj
+
+  Returns a DBIx row object representing a utility (user) QC outcome.
+  Returns an undefined value if the this type of QC outcome is not
+  available for this product.
+
+  npg_qc::Schema object argument is required.
+
+    my $uqc_obj = $p->uqc_obj($schema);
+    print $uqc_obj->is_accepted;
+
+=cut
+
+sub uqc_obj {
+  my ($self, $schema) = @_;
+
+  $schema or croak 'qc schema argument is required';
+
+  return $schema->resultset('UqcOutcomeEnt')
+                ->search_via_composition([$self->composition])->next;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/20-function-pp_archiver.t
+++ b/t/20-function-pp_archiver.t
@@ -1,0 +1,457 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+use Test::Exception;
+use File::Temp qw/tempdir/;
+use File::Path qw/make_path/;
+use File::Copy;
+use Log::Log4perl qw/:levels/;
+use File::Slurp;
+use Moose::Meta::Class;
+use DateTime;
+
+use npg_testing::db;
+
+my $dir = tempdir( CLEANUP => 1);
+
+use_ok('npg_pipeline::function::pp_archiver');
+
+my $exec = join q[/], $dir, 'npg_upload2climb';
+open my $fh1, '>', $exec or die 'failed to open file for writing';
+print $fh1 'echo "npg_upload2climb mock"' or warn 'failed to print';
+close $fh1 or warn 'failed to close file handle';
+chmod 755, $exec;
+local $ENV{PATH} = join q[:], $dir, $ENV{PATH};
+
+my $logfile = join q[/], $dir, 'logfile';
+
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => $logfile,
+                          utf8   => 1});
+
+# setup runfolder
+my $runfolder_path = join q[/], $dir, 'novaseq', '180709_A00538_0010_BH3FCMDRXX';
+my $bbc_path = join q[/], $runfolder_path, 'Data/Intensities/BAM_basecalls_20180805-013153';
+my $archive_path = join q[/], $bbc_path, 'no_cal/archive';
+my $no_archive_path = join q[/], $bbc_path, 'no_archive';
+my $pp_archive_path = join q[/], $bbc_path, 'pp_archive';
+
+make_path $archive_path;
+make_path $no_archive_path;
+copy('t/data/novaseq/180709_A00538_0010_BH3FCMDRXX/RunInfo.xml', "$runfolder_path/RunInfo.xml") or die
+'Copy failed';
+copy('t/data/novaseq/180709_A00538_0010_BH3FCMDRXX/RunParameters.xml', "$runfolder_path/runParameters.xml")
+or die 'Copy failed';
+
+my $timestamp = q[20180701-123456];
+my $repo_dir = q[t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a];
+my $product_conf = qq[$repo_dir/product_release.yml];
+
+local $ENV{NPG_MANIFEST4PP_FILE} = undef;
+
+sub _test_manifest {
+  my $mpath = shift;
+  ok (-f $mpath, 'manifest file exists');
+  my @lines = read_file $mpath;
+  is (scalar @lines, 1, 'manifest contains one line');
+  like ($lines[0], qr/\Asample_name/, 'this line contains a header');
+  unlink $mpath;
+}
+
+subtest 'archiver is not configured: function skipped and an empty manifest generation' => sub {
+  plan tests => 15;
+
+  my $mpath = join q[/], $dir, 'manifest_test1';
+  ok (!-e $mpath, 'prereq - manifest file does not exist');
+
+  my $init = {
+    product_conf_file_path => $product_conf,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+    _manifest_path         => $mpath
+  };
+
+  local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_33990.csv];
+
+  my $f = npg_pipeline::function::pp_archiver->new($init);
+  my $ds = $f->create();
+  is (scalar @{$ds}, 1, '1 definition is returned');
+  isa_ok ($ds->[0], 'npg_pipeline::function::definition');
+  is ($ds->[0]->excluded, 1, 'function is excluded');
+  ok (!-e $mpath, 'manifest file does not exist');
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  is ($f->_generate_manifest4archiver(), 0, 'an empty manifest is generated');
+  _test_manifest($mpath);
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $ds = $f->generate_manifest();
+  is (scalar @{$ds}, 1, '1 definition is returned');
+  isa_ok ($ds->[0], 'npg_pipeline::function::definition');
+  is ($ds->[0]->excluded, 1, 'function is excluded');
+  _test_manifest($mpath);
+};
+
+subtest 'manifest path and using a pre-set path' => sub {
+  plan tests => 16;
+
+  local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_33990.csv];
+
+  my $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => $product_conf,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+
+  my $mpath = $f->_manifest_path;
+  like ($mpath, qr/\A$bbc_path\/manifest4pp_upload_26291_20180701-123456-\d+.tsv\Z/,
+    'generated manifest path is in the analysis directory');
+  is ($ENV{NPG_MANIFEST4PP_FILE}, undef, 'env var is not set');
+
+  $f->generate_manifest();
+  _test_manifest($mpath);
+  is ($ENV{NPG_MANIFEST4PP_FILE}, undef, 'env var is not set');
+
+  $mpath = join q[/], $dir, 'manifest_test12';
+  (not -e $mpath) or die "unexpectedly found existing $mpath";
+  local $ENV{NPG_MANIFEST4PP_FILE} = $mpath;
+
+  $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => $product_conf,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+  is ($f->_manifest_path, $mpath, 'manifest path as pre-set');
+  is ($f->_generate_manifest4archiver(), 0, 'an empty manifest is generated');
+  is ($ENV{NPG_MANIFEST4PP_FILE}, $mpath, 'env var is set');
+  _test_manifest($mpath);
+
+  my $text = 'existing manifest test';
+  write_file($mpath, $text);
+  
+  $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => $product_conf,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+  is ($f->_manifest_path, $mpath, 'manifest path as pre-set');
+  is ($f->_generate_manifest4archiver(), undef, 'manifest is not generated');
+  is ($ENV{NPG_MANIFEST4PP_FILE}, $mpath, 'env var is set');
+  is (read_file($mpath), $text, 'preset manifets has not changed');
+};
+
+subtest 'product config for pp archival validation' => sub {
+  plan tests => 3;
+
+  local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_33990.csv];
+  my $pc = 't/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_two_pps.yml';
+  my $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => $pc,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+  throws_ok { $f->create } 
+    qr/Multiple external archives are not supported/,
+    'error when two versions of the pipeline are marked for archival';
+  
+  $pc = 't/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_no_staging_root.yml';
+  $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => $pc,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+  throws_ok { $f->create } 
+    qr/pp_staging_root is not defined/,
+    'error when the staging root is not defined for a pp which is marked for archival';
+
+  my $new_pc = join q[/], $dir, 'product_release.yml';
+  copy $pc, $new_pc or die "Failed to copy $pc to $new_pc";
+  my $staging = "$dir/staging";
+  write_file($new_pc, {append => 1}, "        pp_staging_root: $staging");
+
+  $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => $new_pc,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+  throws_ok { $f->create }
+    qr/$staging does not exist or is not a directory/,
+    'error when the staging root directory does not exist';
+};
+
+subtest 'definition and manifest generation' => sub {
+  plan tests => 62;
+
+  local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_33990.csv];
+  my $id_run = 26291;
+  my $product_conf =  join(q[/], $dir, 'product_release.yml');
+
+  make_path "$dir/staging"; # create staging root
+
+  my $init = {
+    product_conf_file_path => $product_conf,
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => $id_run,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  };
+
+  my $f = npg_pipeline::function::pp_archiver->new($init);
+  throws_ok { $f->create }
+    qr/qc schema argument is required/, 'db access is required';
+
+  my $schema = Moose::Meta::Class->create_anon_class(roles => [qw/npg_testing::db/])
+    ->new_object()->create_test_db(q[npg_qc::Schema], q[t/data/qc_outcomes/fixtures]);
+  my $uqc_rs = $schema->resultset(q[UqcOutcomeEnt]);
+  is ($uqc_rs->search({})->count, 0, 'no data in uqc_outcome table');
+
+  $init->{qc_schema} = $schema;
+  
+  my %dict = map { $_->short_desc => $_->id_uqc_outcome }
+             $schema->resultset(q[UqcOutcomeDict])->search({})->all();
+  
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  my $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  my $ds = $f->create();
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  is (scalar @{$ds}, 1, '1 definition is returned');
+  is ($ds->[0]->excluded, 1, 'no uqc outcomes, function is excluded');
+
+  my $rows = {};
+  my $cclass = q[npg_tracking::glossary::composition::component::illumina];
+  my $time = DateTime->now();
+
+  for my $tag_index ((1 .. 3)) {
+    my $c = npg_tracking::glossary::composition->new(components => [
+      $cclass->new(id_run => $id_run, position => 1, tag_index => $tag_index),
+      $cclass->new(id_run => $id_run, position => 2, tag_index => $tag_index),
+    ]);
+    my $id = $uqc_rs->find_or_create_seq_composition($c)->id_seq_composition;
+    $rows->{$tag_index} = $uqc_rs->create({
+                             id_seq_composition => $id,
+                             id_uqc_outcome     => $dict{'Accepted'},
+                             username           => 'cat',
+                             modified_by        => 'dog',
+                             rationale          => 'test',
+                             last_modified      => $time
+                           });
+  }
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  ok (-e $manifest_path, 'manifest file exists');
+  is (scalar @{$ds}, 1, '1 definition is returned');
+  my $d = $ds->[0];
+  is ($d->excluded, undef, 'function is not excluded');
+  is ($d->composition, undef, 'composition is not defined');
+  is ($d->job_name, "pp_archiver_$id_run", 'job name');
+  is ($d->command, "$exec $manifest_path", 'correct command');
+
+  ok ($f->merge_lanes, 'merge flag is true');
+  my @data_products = @{$f->products->{'data_products'}};
+  is (scalar @data_products, 5, '5 data products');
+  is (scalar(grep { $f->is_release_data($_) } @data_products), 3,
+    '3 products for release');
+
+  my @lines = read_file($manifest_path);
+  is (scalar @lines, 4, 'manifest contains 4 lines');
+  unlink $manifest_path;
+
+  is ((shift @lines), join(qq[\t],
+    qw(sample_name files_glob staging_archive_path product_json id_product)) . qq[\n],
+    'correct header line');
+  my @line = (
+    'A1',
+    "$pp_archive_path/plex1/ncov2019_artic_nf/v.3/qc_pass_climb_upload/*/*/*{am,fa}",
+    "$dir/staging/26291/BAM_basecalls_20180805-013153/180709_A00538_0010_BH3FCMDRXX",
+    '{"components":[{"id_run":26291,"position":1,"tag_index":1},{"id_run":26291,"position":2,"tag_index":1}]}',
+    "b65be328691835deeff44c4025fadecd9af6512c10044754dd2161d8a7c85000\n"
+  );
+  is ((shift @lines), join(qq[\t], @line), 'correct line for merged plex 1');
+
+  $rows->{1}->update({id_uqc_outcome => $dict{'Rejected'}});
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  ok (-e $manifest_path, 'manifest file exists');
+  @lines = read_file($manifest_path);
+  is (scalar @lines, 3, 'manifest contains 3 lines');
+  unlink $manifest_path;
+
+  $rows->{2}->update({id_uqc_outcome => $dict{'Undecided'}});
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  ok (-e $manifest_path, 'manifest file exists');
+  @lines = read_file($manifest_path);
+  is (scalar @lines, 2, 'manifest contains 2 lines');
+  unlink $manifest_path;
+
+  $rows->{3}->delete();
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  ok (!-e $manifest_path, 'manifest file does no exists');
+  is (scalar @{$ds}, 1, '1 definition is returned');
+  is ($ds->[0]->excluded, 1, 'no uqc outcomes, function is excluded');
+
+  $rows = {};
+
+  for my $p ((1, 2)) {
+    for my $tag_index ((1 .. 3)) {
+      my $c = npg_tracking::glossary::composition->new(components => [
+        $cclass->new(id_run => $id_run, position => $p, tag_index => $tag_index),
+      ]);
+      my $id = $uqc_rs->find_or_create_seq_composition($c)->id_seq_composition;
+      $rows->{$p}->{$tag_index} = $uqc_rs->create({
+                                  id_seq_composition => $id,
+                                  id_uqc_outcome     => $dict{'Accepted'},
+                                  username           => 'cat',
+                                  modified_by        => 'dog',
+                                  rationale          => 'test',
+                                  last_modified      => $time
+                                });
+    }
+  } 
+  
+  $init->{merge_lanes } = 0;
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  is (scalar @{$ds}, 1, 'one definition is generated');
+  is ($ds->[0]->command, "$exec $manifest_path", 'correct command');
+  ok (-e $manifest_path, 'manifest file exists');
+  @lines = read_file($manifest_path);
+  is (scalar @lines, 4, 'manifest contains 4 lines');
+  unlink $manifest_path;
+  shift @lines;
+  @line = (
+    'A1',
+    "$pp_archive_path/lane1/plex1/ncov2019_artic_nf/v.3/qc_pass_climb_upload/*/*/*{am,fa}",
+    "$dir/staging/26291/BAM_basecalls_20180805-013153/180709_A00538_0010_BH3FCMDRXX",
+    '{"components":[{"id_run":26291,"position":1,"tag_index":1}]}',
+    "3709acf46bbedf27819413030709fb2f196ba5e8642b4d2b4319f7bddfa8c2c9\n");
+  is ((shift @lines), join(qq[\t], @line), 'correct line for unmerged plex 1');
+  like ((shift @lines), qr{/lane1/plex2/}, 'correct line for unmerged plex 2');
+  like ((shift @lines), qr{/lane1/plex3/}, 'correct line for unmerged plex 3');
+  
+  $rows->{1}->{1}->update({id_uqc_outcome => $dict{'Rejected'}});
+  $rows->{1}->{2}->update({id_uqc_outcome => $dict{'Undecided'}});
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  is (scalar @{$ds}, 1, 'one definition is generated');
+  is ($ds->[0]->excluded, undef, 'function is not excluded');
+  ok (-e $manifest_path, 'manifest file exists');
+  @data_products = @{$f->products->{'data_products'}};
+  is (scalar @data_products, 10, '10 data products');
+  is (scalar(grep { $f->is_release_data($_) } @data_products), 6,
+    '6 products for release');
+  
+  @lines = read_file($manifest_path);
+  is (scalar @lines, 4, 'manifest contains 4 lines');
+  unlink $manifest_path;
+  shift @lines;
+  like ((shift @lines), qr{/lane2/plex1/}, 'correct line for unmerged plex 1');
+  like ((shift @lines), qr{/lane2/plex2/}, 'correct line for unmerged plex 2');
+  like ((shift @lines), qr{/lane1/plex3/}, 'correct line for unmerged plex 3');
+
+  $rows->{1}->{3}->delete();
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  is (scalar @{$ds}, 1, 'one definition is generated');
+  is ($ds->[0]->excluded, undef, 'function is not excluded');
+  ok (-e $manifest_path, 'manifest file exists');
+  @lines = read_file($manifest_path);
+  is (scalar @lines, 4, 'manifest contains 4 lines');
+  unlink $manifest_path;
+  shift @lines;
+  like ((shift @lines), qr{/lane2/plex1/}, 'correct line for unmerged plex 1');
+  like ((shift @lines), qr{/lane2/plex2/}, 'correct line for unmerged plex 2');
+  like ((shift @lines), qr{/lane2/plex3/}, 'correct line for unmerged plex 3');
+
+  $rows->{2}->{3}->delete();
+
+  $f = npg_pipeline::function::pp_archiver->new($init);
+  $manifest_path = $f->_manifest_path;
+  ok (!-e $manifest_path, 'manifest file does not exist');
+  $ds = $f->create();
+  is (scalar @{$ds}, 1, 'one definition is generated');
+  is ($ds->[0]->excluded, undef, 'function is not excluded');
+  ok (-e $manifest_path, 'manifest file exists');
+  @lines = read_file($manifest_path);
+  is (scalar @lines, 3, 'manifest contains 3 lines');
+  unlink $manifest_path;
+  shift @lines;
+  like ((shift @lines), qr{/lane2/plex1/}, 'correct line for unmerged plex 1');
+  like ((shift @lines), qr{/lane2/plex2/}, 'correct line for unmerged plex 2'); 
+};
+
+subtest 'skip unknown pipeline' => sub {
+  plan tests => 2;
+
+  local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_33990.csv];
+  my $f = npg_pipeline::function::pp_archiver->new(
+    product_conf_file_path => qq[$repo_dir/product_release_unknown_pp.yml],
+    archive_path           => $archive_path,
+    runfolder_path         => $runfolder_path,
+    id_run                 => 26291,
+    timestamp              => $timestamp,
+    repository             => $dir,
+    qc_schema              => undef,
+  );
+
+  my $ds = $f->create();
+  is (scalar @{$ds}, 1, '1 definition is returned');
+  is ($ds->[0]->excluded, 1, 'function is excluded');
+    'unknown pipeline archivable pipeline skipped';
+};
+
+1;

--- a/t/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_no_staging_root.yml
+++ b/t/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_no_staging_root.yml
@@ -12,12 +12,7 @@ study:
   - study_id: "3073"
     portable_pipelines:
       - pp_name: "ncov2019-artic-nf"
-        pp_version: "cf01166c42a"
-        pp_type: "stage2pp"
-        pp_root: "t/data/portable_pipelines"
-        pp_archival_flag: false
-      - pp_name: "new pipeline"
-        pp_version: "v3"
+        pp_version: "v.3"
         pp_type: "stage2pp"
         pp_root: "t/data/portable_pipelines"
         pp_archival_flag: true

--- a/t/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_two_pps.yml
+++ b/t/data/portable_pipelines/ncov2019-artic-nf/v.3/product_release_two_pps.yml
@@ -15,7 +15,9 @@ study:
         pp_version: "cf01166c42a"
         pp_type: "stage2pp"
         pp_root: "t/data/portable_pipelines"
+        pp_archival_flag: true
       - pp_name: "ncov2019-artic-nf"
         pp_version: "v.3"
         pp_type: "stage2pp"
         pp_root: "t/data/portable_pipelines"
+        pp_archival_flag: true


### PR DESCRIPTION
Built on the top of https://github.com/wtsi-npg/npg_seq_pipeline/pull/581

Two pipeline functions are created, 'pp_archiver' and 'pp_archiver_manifest', the former one will be included in the function graph for archival, the latter one just generates a manifest and is intended to be used manually. An existing manifest specified by an env variable NPG_MANIFEST4PP_PATH can be used  by 'pp_archiver'. If a file at the path specified by NPG_MANIFEST4PP_PATH does not exist, it is created. Criteria for products to manifest  - the  pp is flagged for external archival (ie we will not flag a configuration for the R&D study) and uqc pass.

The new function creates a job which will call a as yet not written script, which will take the manifest path as input, stage a directory with hard links and send the data off. Should also check that each of the samples is not  at CLIMB site already