### PR TITLE
allow not to create a definition for a product

### DIFF
--- a/lib/npg_pipeline/function/stage2pp.pm
+++ b/lib/npg_pipeline/function/stage2pp.pm
@@ -62,6 +62,8 @@ sub create {
       my $method = $self->canonical_name($pp_name);
       $method = join q[_], q[], $method, q[create];
       if ($self->can($method)) {
+        # Definition factory method might return an undefined
+        # value, which will be filtered out later.
         push @definitions, $self->$method($product, $pp);
       } else {
         $self->error(sprintf
@@ -71,6 +73,8 @@ sub create {
       }
     }
   }
+
+  @definitions = grep { $_ } @definitions;
 
   if (@definitions) {
     (@definitions == @{$self->_output_dirs}) or $self->logcroak(

--- a/lib/npg_pipeline/function/stage2pp.pm
+++ b/lib/npg_pipeline/function/stage2pp.pm
@@ -17,7 +17,11 @@ with qw{ npg_pipeline::function::util
          npg_pipeline::product::release 
          npg_pipeline::product::release::portable_pipeline };
 with 'npg_common::roles::software_location' =>
-  { tools => [qw/nextflow npg_simple_robo4artic npg_autoqc_generic4artic/] };
+  { tools => [qw/
+                  nextflow
+                  npg_simple_robo4artic
+                  npg_autoqc_generic4artic
+                /] };
 
 Readonly::Scalar my $FUNCTION_NAME => q[stage2pp];
 Readonly::Scalar my $MEMORY        => q[5000]; # memory in megabytes
@@ -28,6 +32,8 @@ our $VERSION = '0';
 =head2 nextflow_cmd
 
 =head2 npg_simple_robo4artic_cmd
+
+=head2 npg_autoqc_generic4artic_cmd
 
 =head2 create
 

--- a/t/20-function-stage2pp.t
+++ b/t/20-function-stage2pp.t
@@ -113,7 +113,7 @@ subtest 'error on missing data in LIMS' => sub {
 };
 
 subtest 'definition generation' => sub {
-  plan tests => 18;
+  plan tests => 20;
 
   local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = q[t/data/samplesheet_33990.csv];
   my $nf_dir = q[t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a];
@@ -154,6 +154,8 @@ subtest 'definition generation' => sub {
   my $c0 = $c;
   is ($ds->[0]->command, $c, 'correct command for plex 1');
   is ($ds->[0]->job_name, 'stage2pp_ncov2cf011_26291', 'job name');
+  is ($ds->[0]->memory, 5000, 'memory');
+  is_deeply ($ds->[0]->num_cpus, [4], 'number of CPUs');
 
   my $c_copy = $command;
   $c_copy =~ s/default/V2/;


### PR DESCRIPTION
will be used when a pipeline has aggregate data from a whole lane