### PR TITLE
Configure status change jobs to save statuses to a database.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,17 @@ LIST OF CHANGES
 
  - Change seq_alignment to observe gbs pipeline allowed or not in product 
    release study config.
+ - Configure status change jobs to optionally save statuses to a database.
+   Use an updated script name in teh job - npg_status_save.
+   Saving to the database is disabled when either the 'local' or
+   'no_db_status_update' attributes are set to true. The description of the new
+   option appears in help. Using --local option is recommended in SOP when
+   testing the pipeline, which will automatically prevent the new version of
+   the job from saving statuses to the database. --local flag ensures that the
+   directory with the new analysis is not visible to the production daemons,
+   including the status daemon. Thus, before this change one of the
+   consequences of using the --local flag was the new statuses not appearing
+   in the database; this will continue to be the case.
 
 release 59.2.0
  - iRODS connections to be opened on-demand for validation

--- a/lib/npg_pipeline/base/options.pm
+++ b/lib/npg_pipeline/base/options.pm
@@ -104,6 +104,22 @@ has q{no_warehouse_update} => (
   documentation => q{Switches off updating the NPG warehouse.},
 );
 
+=head2 no_db_status_update
+
+Switches off creating a database run and lane status record during the status
+update job execution. False by default. Is automatically set to true when the
+C<local> flag is set to true. 
+
+=cut
+
+has q{no_db_status_update} => (
+  isa           => q{Bool},
+  is            => q{ro},
+  lazy          => 1,
+  builder       => '_default_to_local',
+  documentation => q{Switches off updating database run and lane statuses.},
+);
+
 =head2 local
 
 Sets the default for no_irods_archival, no_warehouse_update and

--- a/lib/npg_pipeline/base/options.pm
+++ b/lib/npg_pipeline/base/options.pm
@@ -117,13 +117,13 @@ has q{no_db_status_update} => (
   is            => q{ro},
   lazy          => 1,
   builder       => '_default_to_local',
-  documentation => q{Switches off updating database run and lane statuses.},
+  documentation => q{Switches off run and lane status updates to the database},
 );
 
 =head2 local
 
-Sets the default for no_irods_archival, no_warehouse_update and
-no_summary_link to true.
+Sets the default for no_irods_archival, no_warehouse_update, no_db_status_update
+and no_summary_link attributes to true.
 Defaults to the value of no_bsub flag if no_bsub flag is available.
 
 =cut

--- a/lib/npg_pipeline/function/status.pm
+++ b/lib/npg_pipeline/function/status.pm
@@ -59,11 +59,13 @@ sub _command {
     }
   }
 
-  if (not $self->no_db_status_update) {
-    $command .= q[ --db_save];
+  if ($self->no_db_status_update) {
+    return $command;
+  } else {
+    return $command . q[ --db_save];
   }
 
-  return $command;
+  return;
 }
 
 __PACKAGE__->meta->make_immutable;
@@ -80,10 +82,9 @@ npg_pipeline::function::status
 
 =head1 DESCRIPTION
 
-Launches a job for saving run and lane statuses to a file.
-If saving of statuses to the database is not disabled (C<--no_db_status_update>
-pipeline option is not set explicitly or via setting the C<--local> option),
-the job will also save the statuses to the tracking database. 
+Creates a definition for a job that saves run and lane statuses to a file.
+The job will also save the statuses to the tracking database unless
+C<--no_db_status_update> or C<--local> options are used. 
 
 =head1 SUBROUTINES/METHODS
 

--- a/lib/npg_pipeline/function/status.pm
+++ b/lib/npg_pipeline/function/status.pm
@@ -59,6 +59,10 @@ sub _command {
     }
   }
 
+  if (not $self->no_db_status_update) {
+    $command .= q[ --db_save];
+  }
+
   return $command;
 }
 
@@ -77,6 +81,9 @@ npg_pipeline::function::status
 =head1 DESCRIPTION
 
 Launches a job for saving run and lane statuses to a file.
+If saving of statuses to the database is not disabled (C<--no_db_status_update>
+pipeline option is not set explicitly or via setting the C<--local> option),
+the job will also save the statuses to the tracking database. 
 
 =head1 SUBROUTINES/METHODS
 
@@ -123,7 +130,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2018 Genome Research Ltd
+Copyright (C) 2018,2021 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/npg_pipeline/function/status.pm
+++ b/lib/npg_pipeline/function/status.pm
@@ -9,7 +9,7 @@ with q{npg_pipeline::runfolder_scaffold};
 
 our $VERSION = '0';
 
-Readonly::Scalar my $STATUS_SCRIPT => q{npg_status2file};
+Readonly::Scalar my $STATUS_SCRIPT => q{npg_status_save};
 
 has q{status}           => (isa      => q{Str},
                             is       => q{ro},

--- a/t/20-function-status.t
+++ b/t/20-function-status.t
@@ -60,7 +60,7 @@ subtest 'no_db_status_update option is false (default)' => sub {
   is ($d->job_name, 'save_run_status_1234_run_archived_20090709-123456',
     'job_name is correct');
   is ($d->command,
-    'npg_status2file --id_run 1234 --status "run archived" --dir_out '
+    'npg_status_save --id_run 1234 --status "run archived" --dir_out '
     . $status_dir . q[ --db_save],
     'command is correct');
   ok (!$d->has_composition, 'composition not set');
@@ -83,7 +83,7 @@ subtest 'no_db_status_update option is false (default)' => sub {
   is ($d->job_name, 'save_run_status_1234_qc_complete_20090709-123456',
     'job_name is correct');
   is ($d->command,
-    'npg_status2file --id_run 1234 --status "qc complete" --dir_out '
+    'npg_status_save --id_run 1234 --status "qc complete" --dir_out '
     . $ostatus_dir . q[ --db_save],
     'command is correct');
 
@@ -100,7 +100,7 @@ subtest 'no_db_status_update option is false (default)' => sub {
   is ($d->job_name, 'save_lane_status_1234_analysis_in_progress_20090709-123456',
     'job_name is correct');
   is ($d->command,
-    'npg_status2file --id_run 1234 --status "analysis in progress" --dir_out '
+    'npg_status_save --id_run 1234 --status "analysis in progress" --dir_out '
     . $status_dir .  q' --lanes 3 --lanes 4 --lanes 5 --db_save',
     'command is correct');
 
@@ -116,7 +116,7 @@ subtest 'no_db_status_update option is false (default)' => sub {
   is ($d->job_name, 'save_lane_status_1234_analysis_in_progress_20090709-123456',
     'job_name is correct');
   is ($d->command,
-    'npg_status2file --id_run 1234 --status "analysis in progress" --dir_out '
+    'npg_status_save --id_run 1234 --status "analysis in progress" --dir_out '
     . $status_dir .
     ' --lanes 1 --lanes 2 --lanes 3 --lanes 4 --lanes 5' .
     ' --lanes 6 --lanes 7 --lanes 8 --db_save',
@@ -128,7 +128,7 @@ subtest 'no_db_status_update option is true' => sub {
 
   my $status = 'run archived';
   my $expected_command = sprintf
-    'npg_status2file --id_run 1234 --status "%s" --dir_out %s',
+    'npg_status_save --id_run 1234 --status "%s" --dir_out %s',
     $status, $status_dir;
 
   my $sr = npg_pipeline::function::status->new(

--- a/t/20-function-status.t
+++ b/t/20-function-status.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 27;
+use Test::More tests => 3;
 use Test::Exception;
 use File::Temp qw{ tempdir };
 
@@ -15,10 +15,11 @@ my $status_dir = join q[/], $run_folder_path, 'status';
 my $log_dir = join q[/], $status_dir, 'log';
 
 my %init = (
-  id_run            => 1234,
-  run_folder        => 'myfolder',
-  runfolder_path    => $run_folder_path,
-  bam_basecall_path => $run_folder_path,
+  id_run              => 1234,
+  run_folder          => 'myfolder',
+  runfolder_path      => $run_folder_path,
+  bam_basecall_path   => $run_folder_path,
+  timestamp           => q{20090709-123456},
   resource          => {
     default => {
       memory => 2,
@@ -28,7 +29,9 @@ my %init = (
   }
 );
 
-{
+subtest 'no_db_status_update option is false (default)' => sub {
+  plan tests => 27;
+
   throws_ok {
     npg_pipeline::function::status->new(
       id_run     => 1234,
@@ -40,13 +43,12 @@ my %init = (
   lives_ok {
     $sr = npg_pipeline::function::status->new(
       %init,
-      status            => 'run archived',
-      timestamp         => q{20090709-123456},
+      status => 'run archived'
     )
   } 'status runner object created';
-  isa_ok($sr, 'npg_pipeline::function::status');
-  ok( !$sr->lane_status_flag, 'lane status flag is false by default');
-
+  isa_ok ($sr, 'npg_pipeline::function::status');
+  ok ( !$sr->lane_status_flag, 'lane status flag is false by default');
+  ok ( !$sr->no_db_status_update, q['no_db_status_update' is unset by default]);
   my $da = $sr->create();
   ok ($da && @{$da} == 1, 'an array with one definition is returned');
   my $d = $da->[0];
@@ -59,7 +61,7 @@ my %init = (
     'job_name is correct');
   is ($d->command,
     'npg_status2file --id_run 1234 --status "run archived" --dir_out '
-    . $status_dir,
+    . $status_dir . q[ --db_save],
     'command is correct');
   ok (!$d->has_composition, 'composition not set');
   ok (!$d->excluded, 'step not excluded');
@@ -70,8 +72,7 @@ my %init = (
 
   $sr = npg_pipeline::function::status->new(
     %init,
-    status            => 'qc complete',
-    timestamp         => q{20090709-123456},
+    status => 'qc complete'
   );
   my $ostatus_dir = $status_dir;
   my $olog_dir = $log_dir;
@@ -83,15 +84,14 @@ my %init = (
     'job_name is correct');
   is ($d->command,
     'npg_status2file --id_run 1234 --status "qc complete" --dir_out '
-    . $ostatus_dir,
+    . $ostatus_dir . q[ --db_save],
     'command is correct');
 
   $sr = npg_pipeline::function::status->new(
     %init,
     status            => 'analysis in progress',
     lane_status_flag  => 1,
-    timestamp         => q{20090709-123456},
-    lanes             => [3 .. 5],
+    lanes             => [3 .. 5]
   );
 
   $da = $sr->create();
@@ -101,14 +101,13 @@ my %init = (
     'job_name is correct');
   is ($d->command,
     'npg_status2file --id_run 1234 --status "analysis in progress" --dir_out '
-    . $status_dir .  q' --lanes 3 --lanes 4 --lanes 5',
+    . $status_dir .  q' --lanes 3 --lanes 4 --lanes 5 --db_save',
     'command is correct');
 
   $sr = npg_pipeline::function::status->new(
     %init,
     status            => 'analysis in progress',
-    lane_status_flag  => 1,
-    timestamp         => q{20090709-123456},
+    lane_status_flag  => 1
   );
 
   $da = $sr->create();
@@ -120,8 +119,37 @@ my %init = (
     'npg_status2file --id_run 1234 --status "analysis in progress" --dir_out '
     . $status_dir .
     ' --lanes 1 --lanes 2 --lanes 3 --lanes 4 --lanes 5' .
-    ' --lanes 6 --lanes 7 --lanes 8',
+    ' --lanes 6 --lanes 7 --lanes 8 --db_save',
     'command is correct');
-}
+};
+
+subtest 'no_db_status_update option is true' => sub {
+  plan tests => 4;
+
+  my $status = 'run archived';
+  my $expected_command = sprintf
+    'npg_status2file --id_run 1234 --status "%s" --dir_out %s',
+    $status, $status_dir;
+
+  my $sr = npg_pipeline::function::status->new(
+    %init,
+    status              => $status,
+    no_db_status_update => 1  
+  );
+  ok (!$sr->local, q['local' is false]);
+  my $da = $sr->create();
+  is ($da->[0]->command, $expected_command,
+    q[command is correct when 'no_db_status_update' is set to true explicilty]);
+
+  $sr = npg_pipeline::function::status->new(
+    %init,
+    status => $status,
+    local  => 1  
+  );
+  ok ($sr->no_db_status_update, q['no_db_status_update' is set to true]);
+  $da = $sr->create();
+  is ($da->[0]->command, $expected_command,
+    q[command is correct when 'local' is set to true explicilty]);
+};
 
 1;


### PR DESCRIPTION
Saving to the database is disabled when either the 'local' or
'no_db_status_update' options are set to true.

Depends on https://github.com/wtsi-npg/npg_tracking/pull/615