### PR TITLE
Pass the portable pipeline repository URL to the autoqc generic job.

### DIFF
--- a/lib/npg_pipeline/function/autoqc/generic.pm
+++ b/lib/npg_pipeline/function/autoqc/generic.pm
@@ -218,13 +218,20 @@ sub _command {
 
   my $quote_me = sub { q['] . shift . q[']};
 
-  return join q{ }, $self->qc_cmd,
+  my @common_args = (
+    $self->qc_cmd,
     '--check', $AUTOQC_CHECK_NAME,
     '--spec', $self->spec,
     '--rpt_list', $rpt_list,
     '--pp_name', $quote_me->($self->portable_pipeline_name),
     '--pp_version', $quote_me->($self->pp_version($pp)),
-    @args;
+                    );
+  my $url = $self->pp_repo_url($pp);
+  if ($url) {
+    push @common_args, '--pp_repo_url', $quote_me->($url);
+  }
+
+  return join q[ ], @common_args, @args;
 }
 
 sub _job_name {

--- a/lib/npg_pipeline/product/release/portable_pipeline.pm
+++ b/lib/npg_pipeline/product/release/portable_pipeline.pm
@@ -82,8 +82,9 @@ sub pp_name {
 
 =head2 pp_version
 
-Given a configurationn hash for the portable pipeline,
-returns its version.
+Given a configuration hash for the portable pipeline, returns its version.
+In practice, if git used as Version Control System, either a tag or
+a commit SHA can be used.
 
 =cut
 
@@ -95,7 +96,7 @@ sub pp_version {
 
 =head2 pp_repo_url
 
-Given a configurationn hash for the portable pipeline,
+Given a configuration hash for the portable pipeline,
 returns the URL for its code version control repository.
 
 =cut

--- a/lib/npg_pipeline/product/release/portable_pipeline.pm
+++ b/lib/npg_pipeline/product/release/portable_pipeline.pm
@@ -11,6 +11,7 @@ with 'npg_tracking::util::pipeline_config';
 Readonly::Scalar my $STUDY_CONFIG_SECTION_NAME => q[portable_pipelines];
 Readonly::Scalar my $PP_NAME_KEY               => q[pp_name];
 Readonly::Scalar my $PP_VERSION_KEY            => q[pp_version];
+Readonly::Scalar my $PP_REPO_URL_KEY           => q[pp_repo_url];
 Readonly::Scalar my $PP_TYPE_KEY               => q[pp_type];
 Readonly::Scalar my $PP_ROOT_KEY               => q[pp_root];
 Readonly::Scalar my $PP_ARCHIVAL_FLAG_KEY      => q[pp_archival_flag];
@@ -90,6 +91,19 @@ sub pp_version {
   my ($self, $pp_conf) = @_;
   $pp_conf or croak 'pp config should be defined';
   return $pp_conf->{$PP_VERSION_KEY};
+}
+
+=head2 pp_repo_url
+
+Given a configurationn hash for the portable pipeline,
+returns the URL for its code version control repository.
+
+=cut
+
+sub pp_repo_url {
+  my ($self, $pp_conf) = @_;
+  $pp_conf or croak 'pp config should be defined';
+  return $pp_conf->{$PP_REPO_URL_KEY};
 }
 
 =head2 pps_config4lims_entity

--- a/t/20-function-autoqc-generic.t
+++ b/t/20-function-autoqc-generic.t
@@ -80,6 +80,7 @@ subtest 'definition generation, artic spec' => sub {
     my $command = "$dir/qc --check generic --spec artic " .
       "--rpt_list 26291:$p " .
       q[--pp_name 'ncov2019-artic-nf' --pp_version 'cf01166c42a' ] .
+      q[--pp_repo_url 'https://github.com/connor-lab/ncov2019-artic-nf' ] .
       "--tm_json_file '$archive_path/lane$p/qc/26291_$p.tag_metrics.json' " .
       "--input_files_glob '$pp_archive_path/lane$p/plex*/" .
         q[ncov2019_artic_nf/cf01166c42a/*.qc.csv' ] .

--- a/t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a/product_release.yml
+++ b/t/data/portable_pipelines/ncov2019-artic-nf/cf01166c42a/product_release.yml
@@ -13,6 +13,7 @@ study:
     portable_pipelines:
       - pp_name: "ncov2019-artic-nf"
         pp_version: "cf01166c42a"
+        pp_repo_url: "https://github.com/connor-lab/ncov2019-artic-nf"
         pp_type: "stage2pp"
         pp_root: "t/data/portable_pipelines"
         pp_qc_summary: "*.qc.csv"


### PR DESCRIPTION
pp_repo_url parameter is read from the study configuration for a
portable pipeline and, if defined, is passed to the autoqc generic job
so that the URL can be captured in the information about the autoqc
generic check, which is saved by the generic result object.

Depends on https://github.com/wtsi-npg/npg_qc/pull/762.