### PR TITLE
Update policy for deletion of cancelled and similar runs.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,14 @@
 LIST OF CHANGES
 ---------------
 
+ - npg_run_is_deletable - delete runs with status 'run cancelled' and
+   'data discarded' after 14 days of the status date irrespectively of
+   what study the samples belong to. The samplesheet is not available for
+   these runs. Prior to this change the code was accessing an external
+   source of LIMS data (XML LIMS API) to get information about the study.
+   This change also helps to go around very long deletion times which
+   are set for some studies. 
+
 release 60.1.0
   - GBS - block tag 0 from GBS pipeline and extra tests.
   - Update docs for samplesheet generation


### PR DESCRIPTION
npg_run_is_deletable - delete runs with status 'run cancelled' and
'data discarded' after 14 days of the status date irrespectively of
what study the samples belong to. The samplesheet is not available for
these runs. Prior to this change the code was accessing an external
source of LIMS data (XML LIMS API) to get information about the study.
This change also helps to go around very long deletion times which
are set for some studies.

@jmtc will agree the change with appropriate people.