### PR TITLE
Check for pp archive existence prior to job creation.

### DIFF
--- a/lib/npg_pipeline/function/pp_archiver.pm
+++ b/lib/npg_pipeline/function/pp_archiver.pm
@@ -264,8 +264,9 @@ sub _build__samples4upload {
     $products4archive->{$sname}->{'product'} = $product;
 
     # Where are the files to upload?
-    my $path = $self->_pp_archive4product_existing(
+    my $path = $self->pp_archive4product(
       $product, $self->_pipeline_config, $self->pp_archive_path);
+    $path = $self->_pp_archive4product_existing($path);
     $products4archive->{$sname}->{'pp_data_glob'} =
       catdir($path, $PP_DATA_GLOB);
   }
@@ -357,10 +358,9 @@ sub _build__manifest_path {
 }
 
 sub _pp_archive4product_existing {
-  my ($self, $product, $pp_conf, $path) = @_;
+  my ($self, $suggested_path) = @_;
 
   my $existing_path;
-  my $suggested_path = $self->pp_archive4product($product, $pp_conf, $path);
   if (-e $suggested_path) {
     $existing_path = $suggested_path;
   } else {

--- a/lib/npg_pipeline/product/release/portable_pipeline.pm
+++ b/lib/npg_pipeline/product/release/portable_pipeline.pm
@@ -184,8 +184,9 @@ sub pp_archive4product_relative {
 
 =head2 pp_archive4product
 
-  Returns a product archive for a portable pipeline relative to
-  the supplied path. Can be used as a class method.
+  Returns a product archive for a portable pipeline using the supplied
+  path as a base. The returned path might not exist. Can be used as a
+  class method.
   
   my $apath = $obj->pp_archive4product($product, $pp_conf, $path);
 
@@ -417,7 +418,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2020 Genome Research Ltd.
+Copyright (C) 2020,2021 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Current pp archival cannot cope with data produced by non-current               
pp versions. When the version of an artic pp is updated, the                    
pp archival jobs that are scheduled after the update, but have to                
archive data, which was produced prior to the update, fail.                     
                                                                              
The solution is to check that the pp staging archive for the 'current'          
 pp version exists. If it does not exist, but there is an archive for            
 some other version, data from that staging archive should be archived.          
 Staging archives for multiple pp versions cause the code to error.