### PR TITLE
Added per_product_archive flag.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -243,6 +243,7 @@ t/data/hiseq/samplesheet_16756.csv
 t/data/hiseq/samplesheet_16803.csv
 t/data/hiseq/samplesheet_16807.csv
 t/data/hiseq/samplesheet_20268.csv
+t/data/hiseqx/43416_runParameters.xml
 t/data/hiseqx/16839_RunInfo.xml
 t/data/hiseqx/samplesheet_16839.csv
 t/data/messaging/npg_message_queue.conf

--- a/lib/npg_pipeline/function/pp_data_to_irods_archiver.pm
+++ b/lib/npg_pipeline/function/pp_data_to_irods_archiver.pm
@@ -10,11 +10,10 @@ extends 'npg_pipeline::function::seq_to_irods_archiver';
 
 our $VERSION = '0';
 
-Readonly::Scalar my $IRODS_PP_ROOT       => q{illumina/pp/runs};
 Readonly::Scalar my $PUBLISH_SCRIPT_NAME => q{npg_publish_tree.pl};
 
 has '+irods_root_collection_ns' => (
-  default => $IRODS_PP_ROOT,
+  default => __PACKAGE__->irods_pp_root_collection(),
 );
 
 sub create {

--- a/t/15-product-release-irods.t
+++ b/t/15-product-release-irods.t
@@ -1,18 +1,19 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Test::Exception;
 use Moose::Meta::Class;
+use File::Copy;
 
 use st::api::lims;
+use t::util;
 
 my $package = 'npg_pipeline::product::release::irods';
 use_ok('npg_pipeline::product');
 use_ok($package);
 
-subtest 'iRODS collection path' => sub {
-  plan tests => 9;
-  # These tests cover use of package-level methods only.
+subtest 'iRODS collection paths, package-level methods' => sub {
+  plan tests => 10;
 
   throws_ok {$package->irods_collection4run_rel()} qr/Run id should be given/,
     'error if run is is not given';
@@ -41,6 +42,92 @@ subtest 'iRODS collection path' => sub {
     '/seq/illumina/runs/26/26219', $product, 1),
     '/seq/illumina/runs/26/26219/lane1/plex3',
     'path for a product for a NovaSeq run');
+
+  is ($package->irods_pp_root_collection(), q[illumina/pp/runs],
+    'pp relative root collection');
+};
+
+subtest 'destination collection - instance methods and attributes' => sub {
+  plan tests => 10;
+  
+  my $class = Moose::Meta::Class->create_anon_class(
+    roles => [$package], superclasses => ['npg_pipeline::base']);
+
+  # Tracking db handle is unset explicitly to preven access
+  # to the database, which otherwise might be made.
+
+  my $obj = $class->new_object(
+    id_run => 26219,
+    per_product_archive => 1,
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/illumina/runs/26/26219], 'per-product archive');
+  $obj = $class->new_object(
+    id_run => 26219,
+    runfolder_path => 't/data/novaseq/180709_A00538_0010_BH3FCMDRXX',
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/illumina/runs/26/26219], 'per-product archive');
+  ok ($obj->per_product_archive(),
+    'per-product archive flag is set correctly'); 
+
+  $obj = $class->new_object(
+    id_run => 26219,
+    per_product_archive => 0,
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/26219], 'flat run-level archive');
+
+  my $util = t::util->new();
+  my $paths = $util->create_runfolder(
+    {runfolder_name => '220128_HX9_43416_A_HHCCCCCX2'});
+  my $path = $paths->{runfolder_path};
+  copy 't/data/hiseqx/43416_runParameters.xml', $path .q[/runParameters.xml];
+  $obj = $class->new_object(
+    id_run => 43416,
+    runfolder_path => $path,
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/43416], 'flat run-level archive');
+  ok (!$obj->per_product_archive(),
+    'per-product archive flag is set correctly');
+
+  $obj = $class->new_object(
+    id_run => 43416,
+    per_product_archive => 1,
+    runfolder_path => $path,
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/illumina/runs/43/43416],
+    'per-product archive flag takes precedence over the instrument type');
+   
+  my $pp_root = $obj->irods_pp_root_collection();
+  is ($pp_root, q[illumina/pp/runs], 'pp relative root collection');
+
+  $obj = $class->new_object(
+    id_run => 26219,
+    per_product_archive => 1,
+    irods_root_collection_ns => $pp_root,  
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/illumina/pp/runs/26/26219], 'per-product archive for pp data'); 
+
+  $obj = $class->new_object(
+    id_run => 43416,
+    per_product_archive => 1,
+    runfolder_path => $path,
+    irods_root_collection_ns => $pp_root,
+    npg_tracking_schema => undef
+  );
+  is ($obj->irods_destination_collection(),
+    q[/seq/illumina/pp/runs/43/43416],
+    'per-product archive flag takes precedenceover the instrument type');
 };
 
 subtest 'publishing to iRODS pp archive' => sub {

--- a/t/data/hiseqx/43416_runParameters.xml
+++ b/t/data/hiseqx/43416_runParameters.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+<RunParameters xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Setup>
+    <LimsIntegrationMode>false</LimsIntegrationMode>
+    <NumberOfRehybAttemptsRemaining>2</NumberOfRehybAttemptsRemaining>
+    <ExperimentName>43416</ExperimentName>
+    <ScanID>-999</ScanID>
+    <FCPosition>A</FCPosition>
+    <WorkFlowType>DUALINDEX</WorkFlowType>
+    <Read1>151</Read1>
+    <IndexRead1>8</IndexRead1>
+    <IndexRead2>8</IndexRead2>
+    <Read2>151</Read2>
+    <OutputFolder>\\hx9-esa.dnapipelines.sanger.ac.uk\staging\IL_seq_data\incoming</OutputFolder>
+    <PeriodicSave>Save All Thumbnails</PeriodicSave>
+    <Flowcell>HiSeq X</Flowcell>
+    <FirstBaseConfirmation>true</FirstBaseConfirmation>
+    <SampleSheet />
+    <Sbs>HiSeq X SBS</Sbs>
+    <Pe>HiSeq X PE Dual Index</Pe>
+    <Index>HiSeq X Dual Index Sequencing Primer</Index>
+    <Rehyb>None</Rehyb>
+    <PerformPreRunFluidicsCheck>false</PerformPreRunFluidicsCheck>
+    <ApplicationName>HiSeq Control Software</ApplicationName>
+    <ApplicationVersion>HD 3.5.0.7</ApplicationVersion>
+    <RunID>220128_HX9_43416_A_HHCCCCCX2</RunID>
+    <RunStartDate>220128</RunStartDate>
+    <IntegrationMode>Standalone</IntegrationMode>
+    <BaseSpaceSettings>
+      <Username />
+      <RunId />
+      <InstrumentHealthRunId />
+      <TempFolder />
+      <UseBaseSpace>false</UseBaseSpace>
+      <SendInstrumentHealthToILMN>false</SendInstrumentHealthToILMN>
+      <RunMonitoringOnly>false</RunMonitoringOnly>
+    </BaseSpaceSettings>
+    <ScannerID>ST-E00231</ScannerID>
+    <ScanNumber>669</ScanNumber>
+    <ComputerName>HX9</ComputerName>
+    <FPGAVersion>10.37.13</FPGAVersion>
+    <CPLDVersion>3.0.0</CPLDVersion>
+    <RTAVersion>2.7.7</RTAVersion>
+    <BaseSpaceBrokerVersion>2.9.2.15</BaseSpaceBrokerVersion>
+    <ChemistryVersion>Illumina,Bruno Fluidics Controller,0,v2.0420</ChemistryVersion>
+    <CameraFirmware>2.21-C00-R03</CameraFirmware>
+    <CameraDriver>7.5.190.4396</CameraDriver>
+    <FtdiDriver>2.12.0.0</FtdiDriver>
+    <FocusCameraFirmware />
+    <Barcode>HHCCCCCX2</Barcode>
+    <WashBarcode>HFH72CCX2</WashBarcode>
+    <Username>gkh</Username>
+    <SelectedSections>
+      <Section Name="A_1" />
+      <Section Name="B_1" />
+      <Section Name="C_1" />
+      <Section Name="D_1" />
+      <Section Name="E_1" />
+      <Section Name="F_1" />
+      <Section Name="G_1" />
+      <Section Name="H_1" />
+    </SelectedSections>
+    <FocusMethod>DynamicITF</FocusMethod>
+    <SelectedSurface>BothLaneSurfaces</SelectedSurface>
+    <DoDualSurfaceAutoCenter>true</DoDualSurfaceAutoCenter>
+    <SwathScanMode>AutoSwath</SwathScanMode>
+    <EnableLft>true</EnableLft>
+    <AutoTiltOnce>true</AutoTiltOnce>
+    <EnableAutoCenter>true</EnableAutoCenter>
+    <EnableBasecalling>true</EnableBasecalling>
+    <EnableCameraLogging>false</EnableCameraLogging>
+    <FPGADynamicFocusSettings>
+      <MaxInitialZJumpHalfUm>3</MaxInitialZJumpHalfUm>
+      <MaxSubsequentZJumpHalfUm>7</MaxSubsequentZJumpHalfUm>
+      <NumberOfInitialZJumps>0</NumberOfInitialZJumps>
+      <CVGainStart>250</CVGainStart>
+      <CVGainPosLocked>250</CVGainPosLocked>
+      <Offset>0</Offset>
+      <HotPixel>200</HotPixel>
+      <MotorDelayFrames>21</MotorDelayFrames>
+      <SoftwareLaserLag>1</SoftwareLaserLag>
+      <DitherSize>100</DitherSize>
+      <GroupSize>50</GroupSize>
+      <DitherShift>20</DitherShift>
+      <IntensityCeiling>65535</IntensityCeiling>
+      <IGain>50</IGain>
+      <IHistory>4</IHistory>
+    </FPGADynamicFocusSettings>
+    <TileWidth>3200</TileWidth>
+    <TileHeight>7241</TileHeight>
+    <ImageWidth>3200</ImageWidth>
+    <ImageHeight>174420</ImageHeight>
+    <LaneLength>60.175</LaneLength>
+    <NumTilesPerSwath>24</NumTilesPerSwath>
+    <NumSwaths>2</NumSwaths>
+    <UseExistingRecipe>false</UseExistingRecipe>
+    <Reads>
+      <Read Number="1" NumCycles="151" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="4" NumCycles="151" IsIndexedRead="N" />
+    </Reads>
+    <ReagentKits>
+      <Sbs>
+        <SbsReagentKit>
+          <ID>20536864</ID>
+          <Prime>false</Prime>
+          <NumberCyclesRemaining>325</NumberCyclesRemaining>
+          <IsNew50Cycle>false</IsNew50Cycle>
+          <IsNew150Cycle>false</IsNew150Cycle>
+          <IsNew300Cycle>true</IsNew300Cycle>
+        </SbsReagentKit>
+      </Sbs>
+      <Pe>
+        <ReagentKit>
+          <ID>20536850</ID>
+        </ReagentKit>
+      </Pe>
+    </ReagentKits>
+    <ReagentBottles>
+      <Sbs />
+    </ReagentBottles>
+    <TempFolder>O:\Illumina\HiSeqTemp\220128_HX9_43416_A_HHCCCCCX2</TempFolder>
+    <RecipeFragmentVersion>HD 3.6.0.4</RecipeFragmentVersion>
+    <PromptForPeReagents>false</PromptForPeReagents>
+    <MockRun>false</MockRun>
+    <ScannedBarcode />
+    <CopyImages>false</CopyImages>
+  </Setup>
+  <Version>1</Version>
+</RunParameters>


### PR DESCRIPTION
Added per_product_archive flag to npg_pipeline::product::release::irods
to allow for per-product collection path irrespectively of the
instrument type.
Also added a public method irods_pp_root_collection to get the
relative root of the iRODS collection for portable pipelines data.