### PR TITLE
reverse logic for SamHaplotag --revcomp flag 

### DIFF
--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -314,6 +314,9 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   my $is_haplotag_lib = $l->library_type && ($l->library_type =~ /Haplotagging/smx);
   if($is_haplotag_lib) {
     $p4_param_vals->{haplotag_processing} = q[on];
+    # the samhapotag tool was developed with data from an i5 "rev comp workflow",
+    # its --revcomp flag allows it to work with "standard workflow" i5, as would be
+    # obtained from MiSeq or NovaSeq V1.0 reagents, hence the "not"
     if(not $self->is_i5opposite) {
       $p4_param_vals->{ht_revcomp_flag} = q[on];
     }

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -314,7 +314,7 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   my $is_haplotag_lib = $l->library_type && ($l->library_type =~ /Haplotagging/smx);
   if($is_haplotag_lib) {
     $p4_param_vals->{haplotag_processing} = q[on];
-    # the samhapotag tool was developed with data from an i5 "rev comp workflow",
+    # the samhaplotag tool was developed with data from an i5 "rev comp workflow",
     # its --revcomp flag allows it to work with "standard workflow" i5, as would be
     # obtained from MiSeq or NovaSeq V1.0 reagents, hence the "not"
     if(not $self->is_i5opposite) {

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -314,7 +314,7 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
   my $is_haplotag_lib = $l->library_type && ($l->library_type =~ /Haplotagging/smx);
   if($is_haplotag_lib) {
     $p4_param_vals->{haplotag_processing} = q[on];
-    if($self->is_i5opposite) {
+    if(not $self->is_i5opposite) {
       $p4_param_vals->{ht_revcomp_flag} = q[on];
     }
   }

--- a/t/20-function-seq_alignment.t
+++ b/t/20-function-seq_alignment.t
@@ -1704,6 +1704,7 @@ subtest 'Haplotagging test' => sub {
           's2_tag_index' => 1,
           'reference_genome_fasta' => join(q[/], $dir, 'references/Homo_sapiens/GRCh38_15/all/fasta/Homo_sapiens.GRCh38_15.fa'),
           'haplotag_processing' => 'on',
+          'ht_revcomp_flag' => 'on',
           'seqchksum_orig_file' => join(q[/], $bbd, 'no_cal/archive/lane1/plex1/24135_1#1.orig.seqchksum'),
           'markdup_method' => 'samtools',
           'recal_dir' => join(q[/], $bbd, 'no_cal'),


### PR DESCRIPTION
it should be used when is_i5_opposite attribute is false