### PR TITLE
Fixed the warehouse loader job.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 LIST OF CHANGES
 ---------------
 
+release 62.0.1
+ - Prevent the file glob expansion by the shell when calling a loader
+   for the run parameters XML file. A non-existing file might be passed
+   to the loader.
+
 release 62.0.0
  - Add substitution metrics to the seq alignment command.
  - Removed provisions for loading the old warehouse, the function

--- a/lib/npg_pipeline/function/warehouse_archiver.pm
+++ b/lib/npg_pipeline/function/warehouse_archiver.pm
@@ -88,7 +88,8 @@ sub _update_warehouse_command {
       } else {
         $command = join q{ }, $command, q{&&}, $MLWH_RUNPARAMS_LOADER_NAME,
           q{--id_run}, $self->id_run,
-          q{--path_glob}, $self->runfolder_path . q{/{r,R}unParameters.xml};
+          q{--path_glob},
+          q{'}.$self->runfolder_path . q{/{r,R}unParameters.xml'};
       }
     }
 

--- a/t/20-function-warehouse_archiver.t
+++ b/t/20-function-warehouse_archiver.t
@@ -53,7 +53,7 @@ subtest 'warehouse updates' => sub {
       $job_name .= '_postqccomplete';
     } else {
       $command .= ' && npg_run_params2mlwarehouse --id_run 1234 --path_glob ' .
-        "$runfolder_path/{r,R}unParameters.xml";
+        "'$runfolder_path/{r,R}unParameters.xml'";
     }
 
     my $ds = $c->$m('pname');


### PR DESCRIPTION
Prevented the file glob expansion by the shell when calling
a loader for the run parameters XML file. A non-existing file
might be passed to the loader.