### PR TITLE
allow non consented human split for GBS runs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES
 ---------------
 
+ - allow non consented human split for GBS runs
  - allow analysis of single-end runs with non-consented human split
 
 release 62.0.4

--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -390,7 +390,7 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
    push @{$p4_ops->{prune}}, 'fop.*samtools_stats_F0.*_target.*-';
   }
 
-  my $nchs = $do_gbs_plex ? q{} : $l->contains_nonconsented_human;
+  my $nchs = $l->contains_nonconsented_human;
   my $nchs_template_label = $nchs? q{humansplit_}: q{};
   my $nchs_outfile_label = $nchs? q{human}: q{};
 
@@ -426,13 +426,13 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
     $p4_param_vals->{reference_dict} = $self->_ref($dp, q(picard)) . q(.dict);
     $p4_param_vals->{reference_genome_fasta} = $self->_ref($dp, q(fasta));
     if($self->p4s2_aligner_intfile) { $p4_param_vals->{align_intfile_opt} = 1; }
-    $p4_param_vals->{markdup_method} = $self->markdup_method($dp);
+    $p4_param_vals->{markdup_method} = $do_gbs_plex ? q[none] : $self->markdup_method($dp);
     $p4_param_vals->{markdup_optical_distance_value} = ($uses_patterned_flowcell? $PFC_MARKDUP_OPT_DIST: $NON_PFC_MARKDUP_OPT_DIST);
 
     if($p4_param_vals->{markdup_method} eq q[none]) {
       $skip_target_markdup_metrics = 1;
 
-      if(my $pcb=npg_pipeline::cache::reference->instance->get_primer_panel_bed_file($dp)) {
+      if(my $pcb=npg_pipeline::cache::reference->instance->get_primer_panel_bed_file($dp, $self->repository)) {
         $p4_param_vals->{primer_clip_bed} = $pcb;
         $self->info(qq[No markdup with primer panel: $pcb]);
       }
@@ -442,7 +442,7 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
       }
     }
   }
-  elsif(!$do_rna && !$nchs && !$spike_tag && !$human_split && !$do_gbs_plex && !$is_chromium_lib) {
+  elsif(!$do_rna && !$nchs && !$spike_tag && !$human_split && !$is_chromium_lib) {
       push @{$p4_ops->{prune}}, 'fop.*_bmd_multiway:bam-';
   }
 
@@ -485,9 +485,6 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
      $p4_param_vals->{alignment_method} = $bwa;
      $p4_param_vals->{alignment_reference_genome} = $self->_ref($dp, q(bwa0_6));
      $p4_local_assignments->{'final_output_prep_target'}->{'scramble_embed_reference'} = q[1];
-     if($do_target_alignment) {
-       push @{$p4_ops->{splice}}, 'foptgt_000_bamsort_coord:-foptgt_bmd_multiway:';
-     }
      $skip_target_markdup_metrics = 1;
   }
   elsif($do_rna) {
@@ -524,11 +521,7 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
     $p4_param_vals->{alignment_reference_genome} = $p4_reference_genome_index;
     # create intermediate file to prevent deadlock
     $p4_param_vals->{align_intfile_opt} = 1;
-    if($nchs) {
-      # this human split alignment method is currently the same as the default, but this may change
-      $p4_param_vals->{hs_alignment_reference_genome} = $self->_default_human_split_ref(q{bwa0_6}, $self->repository);
-      $p4_param_vals->{alignment_hs_method} = $hs_bwa;
-    }
+
     if(not $self->is_paired_read) {
       $p4_param_vals->{alignment_reads_layout} = 1;
     }
@@ -578,13 +571,14 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
       $p4_param_vals->{alignment_reference_genome} .= $ref_suffix{$aligner};
     }
 
-    if($nchs) {
-      $p4_param_vals->{hs_alignment_reference_genome} = $self->_default_human_split_ref(q{bwa0_6}, $self->repository);
-      $p4_param_vals->{alignment_hs_method} = $hs_bwa;
-    }
     if(not $self->is_paired_read) {
       $p4_param_vals->{bwa_mem_p_flag} = undef;
     }
+  }
+
+  if($nchs) {
+    $p4_param_vals->{hs_alignment_reference_genome} = $self->_default_human_split_ref(q{bwa0_6}, $self->repository);
+    $p4_param_vals->{alignment_hs_method} = $hs_bwa;
   }
 
   if($human_split) {

--- a/t/20-function-seq_alignment.t
+++ b/t/20-function-seq_alignment.t
@@ -46,6 +46,7 @@ $tbuilds{'3D7_Oct11v3'} = ['genedb_161015_transcriptome'];
 
 my $ref_dir = join q[/],$dir,'references';
 my $tra_dir = join q[/],$dir,'transcriptomes';
+my $prp_dir = join q[/],$dir,'primer_panel';
 foreach my $org (keys %builds){
     foreach my $rel (@{ $builds{$org} }){
         my $rel_dir     = join q[/],$ref_dir,$org,$rel,'all';
@@ -83,7 +84,7 @@ foreach my $gtype_dir (qw/fasta bwa0_6 picard/) {
     make_path($gdir, {verbose => 0});
     `touch $gdir/Hs_MajorQC.fa`;
 }
-
+make_path($prp_dir, {verbose => 0});
 
 my $default = {
   default => {


### PR DESCRIPTION
All human splits were forcibly turned off for GBS runs. Change to allow non consented human split to run where this is configured. 