### PR TITLE
Feature: log irods errors to syslog for npg_publish_tree

### DIFF
--- a/data/config_files/log4perl_publish_tree.conf
+++ b/data/config_files/log4perl_publish_tree.conf
@@ -1,0 +1,29 @@
+# This file can be loaded only if the package Log::Dispatch::Syslog
+# is already installed.
+
+log4perl.logger = INFO, A1, syslog
+
+# Errors from WTSI::NPG::iRODS are propagated in the code to callers,
+# so we do not need to see them directly:
+log4perl.logger.WTSI.NPG.iRODS = OFF, A1, syslog
+
+log4perl.appender.A1 = Log::Log4perl::Appender::Screen
+log4perl.appender.A1.layout = Log::Log4perl::Layout::PatternLayout
+log4perl.appender.A1.layout.ConversionPattern = %d %-5p %c - %m%n
+log4perl.appender.A1.utf8 = 1
+
+# Write only iRODS ERRORs also to syslog to push them to ELK
+
+log4perl.filter.SyslogFilter = Log::Log4perl::Filter::LevelMatch
+log4perl.filter.SyslogFilter.LevelToMatch  = ERROR
+log4perl.filter.SyslogFilter.AcceptOnMatch = true
+
+log4perl.appender.syslog = Log::Dispatch::Syslog
+log4perl.appender.syslog.layout = Log::Log4perl::Layout::PatternLayout
+log4perl.appender.syslog.mode = append
+log4perl.appender.syslog.layout.ConversionPattern = %d %-5p %c - %m%n
+log4perl.appender.syslog.Filter = SyslogFilter
+log4perl.appender.syslog.utf8 = 1
+
+# Prevent duplicate messages with a non-Log4j-compliant Log4perl option
+log4perl.oneMessagePerAppender = 1

--- a/lib/npg_pipeline/function/pp_data_to_irods_archiver.pm
+++ b/lib/npg_pipeline/function/pp_data_to_irods_archiver.pm
@@ -56,6 +56,8 @@ sub create {
         }
       }
 
+      push @args, q{--logconf}, $self->conf_file_path('log4perl_publish_tree.conf');
+
       my %dref = %{$ref};
       $dref{'composition'} = $product->composition;
       $dref{'command'}     = join q[ ], $PUBLISH_SCRIPT_NAME, @args;

--- a/t/20-function-pp_data_to_irods_archiver.t
+++ b/t/20-function-pp_data_to_irods_archiver.t
@@ -6,6 +6,7 @@ use JSON;
 use File::Slurp;
 use Test::More tests => 4;
 use Test::Exception;
+use File::Copy;
 
 my $runfolder_path = 't/data/novaseq/200709_A00948_0157_AHM2J2DRXX';
 my $bbc_path = join q[/], getcwd(), $runfolder_path,
@@ -32,6 +33,8 @@ my %init = (
   }
 );
 
+copy 'data/config_files/log4perl_publish_tree.conf', $init{'conf_path'};
+my $syslog_config = join q[/], $init{'conf_path'}, 'log4perl_publish_tree.conf';
 
 subtest 'local flag' => sub {
   plan tests => 3;
@@ -108,7 +111,8 @@ subtest 'create job definition' => sub {
     q( --include 'ncov2019_artic_nf/v0.(7|8)\\b\\S+trim\\S+/\\S+bam') .
     q( --include 'ncov2019_artic_nf/v0.(11)\\b\\S+trim\\S+/\\S+cram') .
     q( --include 'ncov2019_artic_nf/v0.\\d+\\b\\S+make\\S+/\\S+consensus.fa') .
-    q( --include 'ncov2019_artic_nf/v0.\\d+\\b\\S+call\\S+/\\S+variants.tsv'),
+    q( --include 'ncov2019_artic_nf/v0.\\d+\\b\\S+call\\S+/\\S+variants.tsv') .
+    q( --logconf ) . $syslog_config,
     'correct command');
 
   ok (-e $meta_file, 'metadata file (with sample supplier name) is created');
@@ -147,3 +151,4 @@ subtest 'create job definition' => sub {
 
 };
 
+unlink $syslog_config;


### PR DESCRIPTION
Added
- `data/config_files/log4perl_publish_tree.conf` : Log4perl configuration file with the Syslog Dispatcher for npg_publish_tree

Changed
- `t/20-function-pp_data_to_irods_archiver.t`: Update the test of npg_publish_tree.pl command line with the --logconf argument and the Syslog Dispatcher file
- `lib/npg_pipeline/function/pp_data_to_irods_archiver.pm`: Add the --logconf option to the generated call of npg_publish_tree.pl from the pipeline