### PR TITLE
remove constraint of p4s1 to specific flavor

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ LIST OF CHANGES
 release 64.0.0
  - add bwa_mem2 flag to options.pm to allow override of default bwa analyses at pipeline invocation
  - update seq_alignment to recognise the bwa_mem2 flag and also default to bwa_mem2 for NovaSeqX platform
+ - remove wr limit of p4s1 to specific flavor
 
 release 63.3.0
  - force no_target_alignment for haplotag libraries

--- a/data/config_files/wr.json
+++ b/data/config_files/wr.json
@@ -2,6 +2,6 @@
  "default_queue":{},
  "small_queue":{},
  "lowload_queue":{},
- "p4stage1_queue":{"cloud_flavor":"ukb1.2xlarge"},
+ "p4stage1_queue":{},
  "limit_grps":["irods", "s3"]
 }

--- a/t/30-executor-wr.t
+++ b/t/30-executor-wr.t
@@ -38,9 +38,7 @@ subtest 'wr conf file' => sub {
   is (ref $conf, 'HASH', 'configuration is a hash ref');
   while (my ($key, $value) = each %{$conf}) {
     if ( $key =~ /queue\Z/ ) {
-      is_deeply ($value,
-      $key =~ /\Ap4stage1/ ? {'cloud_flavor' => 'ukb1.2xlarge'} : {},
-      "correct settings for $key");
+      is_deeply ($value, {}, "correct settings for $key");
     }
   }
 };


### PR DESCRIPTION
Wondering if it is best to remove the key `p4stage1_queue`. There is other test in the same `t/30-executor-wr.t` file which checks that if there is a value it is picked up. I think the test I changed was there just to make sure the key force the flavour we wanted. @dkj @mgcam 