### PR TITLE
Runs with data analysed on-board are not deletable.

### DIFF
--- a/.github/workflows/testing_and_building_repo.yml
+++ b/.github/workflows/testing_and_building_repo.yml
@@ -1,5 +1,7 @@
 name: testing_and_building_repo
 on: [push, pull_request]
+env:
+  WTSI_NPG_BUILD_BRANCH: ${{ github.base_ref || github.ref }}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -50,7 +52,6 @@ jobs:
           ${GITHUB_WORKSPACE}/scripts/install_npg_perl_dependencies.sh $WTSI_NPG_GITHUB_URL $WTSI_NPG_BUILD_BRANCH
       env:
         WTSI_NPG_GITHUB_URL: https://github.com/wtsi-npg
-        WTSI_NPG_BUILD_BRANCH: ${GITHUB_HEAD_REF} #getting name of current github branch
 
     - name: Install cpanm dependencies
       run: |

--- a/lib/npg_pipeline/validation.pm
+++ b/lib/npg_pipeline/validation.pm
@@ -468,6 +468,7 @@ sub run {
               $self->_lims_deletable()         &&
               $self->_staging_deletable()      &&
               $self->_irods_seq_deletable()    &&
+              $self->_irods_seq_onboard_deletable() &&
               $self->_s3_deletable()           &&
               $self->_autoqc_deletable()       &&
               $self->_file_archive_deletable
@@ -831,6 +832,11 @@ sub _irods_seq_pp_deletable {
   return $deletable;
 }
 
+sub _irods_seq_onboard_deletable {
+  my $self = shift;
+  return !$self->onboard_analysis_planned();
+}
+
 sub _irods_destination_collection4pp {
   my $self = shift;
 
@@ -1109,7 +1115,7 @@ __END__
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2019,2020,2021,2022 Genome Research Ltd.
+Copyright (C) 2019,2020,2021,2022,2023 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/t/10-validation.t
+++ b/t/10-validation.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 8;
 use Test::Exception;
 use Test::Warn;
 use Test::Trap qw/ :warn /;
@@ -332,6 +332,30 @@ subtest 'per product flag and iRODS locations' => sub {
   ok ($v->per_product_archive, 'per product iRODS is true');
   is ($v->irods_destination_collection, '/seq-dev/8747',
     'iRODS collection as set');
+};
+
+subtest 'presence of onboard analysis results' => sub {
+  plan tests => 2;
+
+  my $rf_path = tempdir(CLEANUP => 1);
+
+  copy('t/data/run_params/RunParameters.novaseqx.xml',
+    "$rf_path/RunParameters.xml");
+  my $v = npg_pipeline::validation->new(
+    id_run => 47539,
+    runfolder_path => $rf_path
+  );
+  ok (!$v->_irods_seq_onboard_deletable(),
+    'NovaSeqX with onboard analysis - not deletable');
+
+  copy('t/data/run_params/runParameters.novaseq.xml',
+    "$rf_path/RunParameters.xml"); 
+  $v = npg_pipeline::validation->new(
+    id_run => 9999,
+    runfolder_path => $rf_path
+  );
+  ok ($v->_irods_seq_onboard_deletable(),
+    'NovaSeq - no onboard analysis - deletable');
 };
 
 1;


### PR DESCRIPTION
Currently we do not archive the output of the onboard analysis. We will keep the run folders around till we are able to archive this output and can validate this archival.

Depends on https://github.com/wtsi-npg/npg_tracking/pull/742