### PR TITLE
Stop tests creating data in the source tree.

### DIFF
--- a/t/15-product-release-irods.t
+++ b/t/15-product-release-irods.t
@@ -82,7 +82,7 @@ subtest 'destination collection - instance methods and attributes' => sub {
     q[/seq/26219], 'flat run-level archive');
 
   my $util = t::util->new();
-  my $paths = $util->create_runfolder(
+  my $paths = $util->create_runfolder(undef,
     {runfolder_name => '220128_HX9_43416_A_HHCCCCCX2'});
   my $path = $paths->{runfolder_path};
   copy 't/data/hiseqx/43416_runParameters.xml', $path .q[/runParameters.xml];

--- a/t/20-function-pp_data_to_irods_archiver.t
+++ b/t/20-function-pp_data_to_irods_archiver.t
@@ -6,10 +6,15 @@ use JSON;
 use File::Slurp;
 use Test::More tests => 4;
 use Test::Exception;
-use File::Copy;
+use File::Copy::Recursive qw(fcopy dircopy);
+use File::Temp qw(tempdir);
 
-my $runfolder_path = 't/data/novaseq/200709_A00948_0157_AHM2J2DRXX';
-my $bbc_path = join q[/], getcwd(), $runfolder_path,
+my $tdir = tempdir(CLEANUP => 1);
+my $rf_name = '200709_A00948_0157_AHM2J2DRXX';
+my $runfolder_path = join q[/], $tdir, $rf_name;
+dircopy("t/data/novaseq/$rf_name", $runfolder_path);
+
+my $bbc_path = join q[/], $runfolder_path,
                'Data/Intensities/BAM_basecalls_20200710-105415';
 
 local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = join q[/], $bbc_path,
@@ -33,7 +38,7 @@ my %init = (
   }
 );
 
-copy 'data/config_files/log4perl_publish_tree.conf', $init{'conf_path'};
+fcopy 'data/config_files/log4perl_publish_tree.conf', $init{'conf_path'};
 my $syslog_config = join q[/], $init{'conf_path'}, 'log4perl_publish_tree.conf';
 
 subtest 'local flag' => sub {


### PR DESCRIPTION
t/20-function-pp_data_to_irods_archiver.t - set up a test runfolder in a temporary directory.

t/15-product-release-irods.t - correctly use test utility library function.