### PR TITLE
Extended the dir_path method of the product.

### DIFF
--- a/lib/npg_pipeline/product/release/irods.pm
+++ b/lib/npg_pipeline/product/release/irods.pm
@@ -202,7 +202,7 @@ sub irods_product_destination_collection_norf {
   $run_collection or croak('Run collection iRODS path is required');
   $product or croak('Product object is required');
   return $per_product_archive
-    ? join q[/], $run_collection, $product->dir_path($product->selected_lanes)
+    ? join q[/], $run_collection, $product->dir_path()
     : $run_collection;
 }
 
@@ -338,7 +338,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2019,2020,2021,2022 Genome Research Ltd.
+Copyright (C) 2019,2020,2021,2022,2024 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/t/10-validation-entity.t
+++ b/t/10-validation-entity.t
@@ -62,7 +62,7 @@ subtest 'description' => sub {
 };
 
 subtest 'relative_path' => sub {
-  plan tests => 5;
+  plan tests => 6;
 
   my $product = npg_pipeline::product->new(rpt_list => '1:2');
   my $entity = npg_pipeline::validation::entity->new(
@@ -100,6 +100,17 @@ subtest 'relative_path' => sub {
     target_product       => $product
   );
   is ($entity->entity_relative_path, q[plex3], 'plex13 relative path');
+
+  $product = npg_pipeline::product->new(
+    rpt_list => q[22:2:3;22:3:3],
+    selected_lanes => 1
+  );
+  $entity = npg_pipeline::validation::entity->new(
+    staging_archive_root => q[t],
+    target_product       => $product
+  );
+  is ($entity->entity_relative_path, q[lane2-3/plex3],
+    'lane2-3/plex13 relative path for a partial merge');
 };
 
 subtest 'entity_staging_path' => sub {


### PR DESCRIPTION
Wrapped around the inherited method in npg_pipeline::product so that it works for partial merges. Removed a flag that previously has to be passed to this method.

This fixes a bug in npg_pipeline::validation::entity - incorrect prediction of paths for partial merges.