### PR TITLE
Changed mark duplicate method retrieval.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 ---------------
 
+ - Ensured mark duplicate method can be inferred for a product with multiple
+   studies (tag zero).
+
 release 68.3.0 (2024-05-24)
  - Removing Tidyp dependency from CI
  - Added 'SampleSheet.csv' file from the top level of the run folder to


### PR DESCRIPTION
Ensured mark duplicate method can be inferred for a product with multiple studies.

Depends on https://github.com/wtsi-npg/npg_tracking/pull/833