### PR TITLE
Review check - runfolder_path arg is added.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 ---------------
 
+ - The runfolder_path argument is added to the command for the autoqc review
+   check. See https://github.com/wtsi-npg/npg_qc/pull/869
+
 release 68.4.0 (2024-08-06)
  - Ensured mark duplicate method can be inferred for a product with multiple
    studies (tag zero).

--- a/lib/npg_pipeline/function/autoqc.pm
+++ b/lib/npg_pipeline/function/autoqc.pm
@@ -271,8 +271,8 @@ sub _generate_command {
     $c .= q[ ] . join q[ ], (map {"--qc_in=$_"} (keys %qc_in_roots));
   }
   elsif($check eq q/review/) {
-    $c .= q{ --qc_in=} . $qc_out_path;
-    $c .= q{ --conf_path=} . $self->conf_path;
+    $c .= sprintf q{ --qc_in=%s --conf_path=%s --runfolder_path=%s},
+      $qc_out_path, $self->conf_path, $self->runfolder_path;
   }
   else {
     ## default input_files [none?]

--- a/t/20-function-autoqc.t
+++ b/t/20-function-autoqc.t
@@ -615,13 +615,15 @@ subtest 'review' => sub {
   my $d = $definitions{'8747:8'};
   my $expected_command = q{qc --check=review --rpt_list="8747:8" } .
     qq{--filename_root=8747_8 --qc_out=$archive_dir/lane8/qc } .
-    qq{--qc_in=$archive_dir/lane8/qc --conf_path=t/data/release/config/qc_review};
+    qq{--qc_in=$archive_dir/lane8/qc --conf_path=t/data/release/config/qc_review } .
+    qq{--runfolder_path=$rf_path};
   is ($d->command, $expected_command, 'correct command for lane-level job');
 
   $d = $definitions{'8747:1:1'};
   $expected_command = q{qc --check=review --rpt_list="8747:1:1" } .
     qq{--filename_root=8747_1#1 --qc_out=$archive_dir/lane1/plex1/qc } .
-    qq{--qc_in=$archive_dir/lane1/plex1/qc --conf_path=t/data/release/config/qc_review};
+    qq{--qc_in=$archive_dir/lane1/plex1/qc --conf_path=t/data/release/config/qc_review } .
+    qq{--runfolder_path=$rf_path};
   is ($d->command, $expected_command, 'correct command for plex-level job');
 };
 


### PR DESCRIPTION
The runfolder_path argument is added to the command for the autoqc review check. See https://github.com/wtsi-npg/npg_qc/pull/869