### PR TITLE
Fix URL to use Miniforge rather than Mambaforge

### DIFF
--- a/scripts/install_miniforge.sh
+++ b/scripts/install_miniforge.sh
@@ -8,8 +8,8 @@
 
 set -ex
 
-MINIFORGE_VERSION="24.9.0-0"
-MINIFORGE_SHA256="77fb505f6266ffa1b5d59604cf6ba25948627e908928cbff148813957b1c28af"
+MINIFORGE_VERSION="24.9.2-0"
+MINIFORGE_SHA256="ca8c544254c40ae5192eb7db4e133ff4eb9f942a1fec737dba8205ac3f626322"
 
 CONDA_HOME=${CONDA_HOME:="$HOME/conda"}
 export CONDA_HOME
@@ -27,7 +27,7 @@ channels:
   - conda-forge
 EOF
 
-curl -sSL "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Mambaforge-${MINIFORGE_VERSION}-Linux-x86_64.sh" -o ./miniforge.sh
+curl -sSL "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh" -o ./miniforge.sh
 sha256sum ./miniforge.sh | grep "$MINIFORGE_SHA256"
 /bin/bash ./miniforge.sh -b -p "$CONDA_HOME"
 rm ./miniforge.sh


### PR DESCRIPTION
Based on https://github.com/wtsi-npg/npg_qc/commit/ca05637d0ee06974763521a6b63e0208fbb7fb19 by @kjsanger 