### PR TITLE
no readname prefixing/removal for bowtie2 nchs

### DIFF
--- a/lib/npg_pipeline/function/seq_alignment.pm
+++ b/lib/npg_pipeline/function/seq_alignment.pm
@@ -595,7 +595,10 @@ sub _alignment_command { ## no critic (Subroutines::ProhibitExcessComplexity)
     $p4_param_vals->{hs_alignment_reference_genome} = $self->_default_human_split_ref(q{bowtie2}, $self->repository);
     $p4_param_vals->{alignment_hs_method} = q{bowtie2};
 
+    push @{$p4_ops->{splice}}, q[aln_prealn_hs_bamcollate2_ranking];
     push @{$p4_ops->{splice}}, q[aln_prealn_hs_bamadapterclip];
+    push @{$p4_ops->{splice}}, q[aln_postaln_hs_bam12split];
+    $p4_param_vals->{rankstrip_nchs_val} = 0;
   }
 
   if($human_split) {


### PR DESCRIPTION
nchs human alignment: remove collate3 and bam12split nodes, set human alignment bam12auxmerge ranksplit flag to 0 (no readname prefixing/removal for bowtie2)