### PR TITLE
no_sf_resource pipeline option is set to true

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 LIST OF CHANGES
 ---------------
 
+ - Changed the default value for the no_sf_resource pipeline option from
+   false to true. Our staging areas are currently on lustre, so we do not
+   have to limit the number of jobs simultaneously accessing the file system. 
+
 release 68.15.0 (2026-01-06)
  - remove production of BAM outputs for most stage2 processing
    except aligned human; RNA analysis; spike tag; and chromium libraries

--- a/lib/npg_pipeline/executor/options.pm
+++ b/lib/npg_pipeline/executor/options.pm
@@ -69,8 +69,9 @@ Do not use sf resource tokens; set if working outside the npg sequencing farm
 has q{no_sf_resource} => (
   isa           => q{Bool},
   is            => q{ro},
+  default       => 1,
   documentation =>
-  q{Do not use sf resource tokens},
+  q{Do not use sf resource tokens, defaults to true},
 );
 
 =head2 no_bsub

--- a/t/10-pluggable.t
+++ b/t/10-pluggable.t
@@ -285,7 +285,7 @@ subtest 'creating executor object' => sub {
 };
 
 subtest 'propagating options to the lsf executor' => sub {
-  plan tests => 14;
+  plan tests => 13;
 
   my @functions_in_order = qw(
     run_archival_in_progress
@@ -306,10 +306,12 @@ subtest 'propagating options to the lsf executor' => sub {
   my $p = npg_pipeline::pluggable->new($ref);
   my $e = $p->executor();
 
-  my @boolean_attrs = qw/interactive no_sf_resource no_bsub no_array_cpu_limit/;
+  my @boolean_attrs = qw/interactive no_bsub no_array_cpu_limit/;
   for my $attr (@boolean_attrs) {
     ok (!$e->$attr, "executor: $attr value is false");
   }
+
+  ok ($e->no_sf_resource, "executor: no_sf_resource value is true"); 
 
   for my $attr (qw/job_name_prefix job_priority array_cpu_limit/) {
     my $predicate = "has_$attr";


### PR DESCRIPTION
Our staging areas are currently on lustre, so we do not have to limit the number of jobs simultaneously
accessing the file system.